### PR TITLE
184 do not run a calculation if its set up failed

### DIFF
--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -160,16 +160,14 @@ class ADFJob(AMSJob):
         self._functional = functional
 
         if functional == 'r2SCAN-3c' and self._basis_set != 'mTZ2P':
-            log.warn(f'Switching basis set from {self._basis_set} to mTZ2P for r2SCAN-3c.')
+            log.info(f'Switching basis set from {self._basis_set} to mTZ2P for r2SCAN-3c.')
             self.basis_set('mTZ2P')
 
         if functional == 'SSB-D':
-            log.error('There are two functionals called SSB-D, please use "GGA:SSB-D" or "MetaGGA:SSB-D".')
-            return
+            raise ValueError('There are two functionals called SSB-D, please use "GGA:SSB-D" or "MetaGGA:SSB-D".')
 
         if not data.functionals.get(functional):
-            log.warn(f'XC-functional {functional} not found. Please ask a TheoCheM developer to add it. Adding functional as LibXC.')
-            self.settings.input.adf.XC.LibXC = functional
+            raise ValueError(f'XC-functional {functional} not found.')
         else:
             func = data.functionals.get(functional)
             self.settings.input.adf.update(func.adf_settings)

--- a/src/tcutility/job/generic.py
+++ b/src/tcutility/job/generic.py
@@ -40,7 +40,12 @@ class Job:
     def __enter__(self):
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        if exc_type:
+            fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
+            log.error(f'Job set-up failed with exception:')
+            log.error(f'    {exc_type.__name__}({exc_value}) in File "{fname}", line {exc_tb.tb_lineno}.')
+            return True
         self.run()
 
     def can_skip(self):

--- a/src/tcutility/job/generic.py
+++ b/src/tcutility/job/generic.py
@@ -43,8 +43,7 @@ class Job:
     def __exit__(self, exc_type, exc_value, exc_tb):
         if exc_type:
             fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
-            log.error(f'Job set-up failed with exception:')
-            log.error(f'    {exc_type.__name__}({exc_value}) in File "{fname}", line {exc_tb.tb_lineno}.')
+            log.error(f'Job set-up failed with exception: {exc_type.__name__}({exc_value}) in File "{fname}", line {exc_tb.tb_lineno}.')
             return True
         self.run()
 


### PR DESCRIPTION
Jobs now do not run if an exception occured in its setup, but will not crash the program.