### PR TITLE
Added tcutility.log.rectangle_list

### DIFF
--- a/src/tcutility/log.py
+++ b/src/tcutility/log.py
@@ -216,7 +216,7 @@ def rectangle_list(values: List, spaces_before: int = 0, level: int = 20):
 
     # then print the strings with the right column widths
     for row in prev_mat:
-        log(" " * spaces_before + "  ".join([x.ljust(col_len) for x, col_len in zip(row, prev_col_lens)]))
+        log(" " * spaces_before + "  ".join([x.ljust(col_len) for x, col_len in zip(row, prev_col_lens)]), level=level)
 
 
 def loadbar(sequence: Iterable, comment: str = "", Nsegments: int = 50, Nsteps: int = 10, level: int = 20) -> None:

--- a/src/tcutility/log.py
+++ b/src/tcutility/log.py
@@ -8,6 +8,7 @@ from tcutility import ensure_2d
 from typing import Any, Iterable, List, Union
 from types import GeneratorType
 import inspect
+from math import ceil
 # from threading import Thread
 
 
@@ -199,12 +200,12 @@ def rectangle_list(values: List, spaces_before: int = 0, level: int = 20):
         # the number of rows for the number of columns
         nrows = ceil(len(values) / ncol)
         # we then get what the rectangle would be
-        mat = [str(values[i * ncol: (i+1) * ncol]) for i in range(nrows)]
+        mat = [[str(x) for x in values[i * ncol: (i+1) * ncol]] for i in range(nrows)]
         # and determine for each column the width
         col_lens = [max([len(row[i]) for row in mat if i < len(row)] + [0]) for i in range(ncol)]
         # then calculate the length of each row based on the column lengths
         # we use a spacing of 2 spaces between each column
-        row_len = spaces_before + sum(col_lens) + 2 * len(col_lens) - 2
+        row_len = 22 * print_date + spaces_before + sum(col_lens) + 2 * len(col_lens) - 2
 
         # if the rows are too big we exit the loop
         if row_len > n_shell_col:
@@ -479,3 +480,5 @@ if __name__ == "__main__":
             log.warn("I am testing the warning function")
 
     TestClass().test_method()
+
+    rectangle_list(range(1000))

--- a/src/tcutility/log.py
+++ b/src/tcutility/log.py
@@ -188,6 +188,37 @@ def table(rows: List[List[Any]], header: Union[List[str], None] = None, sep: str
     return return_str
 
 
+def rectangle_list(values: List, spaces_before: int = 0, level: int = 20):
+    '''
+    This function prints a list of strings in a rectangle to the output.
+    This is similar to what the ls program does in unix.
+    '''
+    n_shell_col = os.get_terminal_size().columns
+    # we first have to determine the correct dimensions of our rectangle
+    for ncol in range(1, n_shell_col):
+        # the number of rows for the number of columns
+        nrows = ceil(len(values) / ncol)
+        # we then get what the rectangle would be
+        mat = [str(values[i * ncol: (i+1) * ncol]) for i in range(nrows)]
+        # and determine for each column the width
+        col_lens = [max([len(row[i]) for row in mat if i < len(row)] + [0]) for i in range(ncol)]
+        # then calculate the length of each row based on the column lengths
+        # we use a spacing of 2 spaces between each column
+        row_len = spaces_before + sum(col_lens) + 2 * len(col_lens) - 2
+
+        # if the rows are too big we exit the loop
+        if row_len > n_shell_col:
+            break
+
+        # store the previous loops results
+        prev_col_lens = col_lens
+        prev_mat = mat
+
+    # then print the strings with the right column widths
+    for row in prev_mat:
+        log(" " * spaces_before + "  ".join([x.ljust(col_len) for x, col_len in zip(row, prev_col_lens)]))
+
+
 def loadbar(sequence: Iterable, comment: str = "", Nsegments: int = 50, Nsteps: int = 10, level: int = 20) -> None:
     """
     Return values from an iterable ``sequence`` and also print a progress bar for the iteration over this sequence.


### PR DESCRIPTION
This PR will add the `tcutility.log.rectangle_list` function that prints a list of string values as a rectangle that fits the shell that the user is using.

E.g.
```python
>>> from tcutility import log
>>> log.rectangle_list(range(200))
[2024/04/30 22:15:29] 0    1    2    3    4    5    6    7    8    9    10   11   12   13   14   15   16   17 
[2024/04/30 22:15:29] 18   19   20   21   22   23   24   25   26   27   28   29   30   31   32   33   34   35 
[2024/04/30 22:15:29] 36   37   38   39   40   41   42   43   44   45   46   47   48   49   50   51   52   53 
[2024/04/30 22:15:29] 54   55   56   57   58   59   60   61   62   63   64   65   66   67   68   69   70   71 
[2024/04/30 22:15:29] 72   73   74   75   76   77   78   79   80   81   82   83   84   85   86   87   88   89 
[2024/04/30 22:15:29] 90   91   92   93   94   95   96   97   98   99   100  101  102  103  104  105  106  107
[2024/04/30 22:15:29] 108  109  110  111  112  113  114  115  116  117  118  119  120  121  122  123  124  125
[2024/04/30 22:15:29] 126  127  128  129  130  131  132  133  134  135  136  137  138  139  140  141  142  143
[2024/04/30 22:15:29] 144  145  146  147  148  149  150  151  152  153  154  155  156  157  158  159  160  161
[2024/04/30 22:15:29] 162  163  164  165  166  167  168  169  170  171  172  173  174  175  176  177  178  179
[2024/04/30 22:15:29] 180  181  182  183  184  185  186  187  188  189  190  191  192  193  194  195  196  197
[2024/04/30 22:15:29] 198  199
```