### PR TITLE
Check job pre-run function

### DIFF
--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -253,6 +253,12 @@ class ADFJob(AMSJob):
         '''
         self.settings.input.adf.Symmetry = group
 
+    def _check_job(self):
+        # if we have spinpolarization we do not want to use DFTB to calculate the initial hessian
+        if self.settings.input.adf.SpinPolarization != 0 and self.settings.input.ams.GeometryOptimization.InitialHessian.Type == 'CalculateWithFastEngine':
+            # we simply remove it from the geometryoptimization block
+            self.settings.input.ams.GeometryOptimization.pop('InitialHessian', None)
+
 
 class ADFFragmentJob(ADFJob):
     def __init__(self, *args, **kwargs):

--- a/src/tcutility/job/ams.py
+++ b/src/tcutility/job/ams.py
@@ -192,6 +192,10 @@ class AMSJob(Job):
         if not self._molecule:
             self.settings.input.ams.system.GeometryFile = self._molecule_path
 
+        # sometimes we have to check if a job is able to run or requires some special consideration
+        # those types of checks should be defined in _check_job
+        self._check_job()
+
         # we will use plams to write the input and runscript
         sett = self.settings.as_plams_settings()
         job = plams.AMSJob(name=self.name, molecule=self._molecule, settings=sett)
@@ -211,6 +215,9 @@ class AMSJob(Job):
             os.remove(j(self.workdir, 'ams.log'))
 
         return True
+
+    def _check_job(self):
+        ...
 
     @property
     def output_mol_path(self):


### PR DESCRIPTION
Added a AMSJob method that is always called before the calculation is run. This is used, currently, to make sure that the initialhessian is not set to DFTB if spin-polarized ADF calculation was requested.