### PR TITLE
Citation page-ranges now use the correct dash

### DIFF
--- a/src/tcutility/cite.py
+++ b/src/tcutility/cite.py
@@ -87,7 +87,7 @@ def _format_article(data: dict, style: str) -> str:
 	journal_abbreviation = _get_journal_abbreviation(journal)
 	year = data['message']['issued']['date-parts'][0][0]
 	volume = data['message']['volume']
-	pages = data['message'].get('page')
+	pages = data['message'].get('page').replace('-', '–')
 	title = data['message']['title'][0]
 	doi = data['message']['DOI']
 


### PR DESCRIPTION
The solution was to simply replace the normal dash with the correct one before formatting the citation.