### PR TITLE
Asterisk can now used as radical dots when formatting molecular formulas

### DIFF
--- a/src/tcutility/formula.py
+++ b/src/tcutility/formula.py
@@ -4,13 +4,13 @@ from scm import plams
 
 def parse_molecule(molecule: plams.Molecule) -> str:
     """
-    Analyse a molecule and return the molstring describing its parts. Each part will then be separated by a + sign in the new string.
+    Analyse a molecule and return the molstring describing its parts. Each part will then be separated by a `+` sign in the new string.
 
     Args:
-        molecule: plams.Molecule object to be parsed.
+        molecule: `plams.Molecule` object to be parsed.
 
     Returns:
-        A string that contains each part of the molecule separated by a + sign, for use in TCutility.formula.molecule function for further formatting.
+        A string that contains each part of the molecule separated by a `+` sign, for use in TCutility.formula.molecule function for further formatting.
     """
     # to separate a molecule we need to have bonds
     molecule.guess_bonds()
@@ -22,6 +22,7 @@ def parse_molecule(molecule: plams.Molecule) -> str:
         # add all elements with their number, but only if the number is larger than 1.
         # this prevents the creation of strings containing e.g. C1H3Cl2
         parts.append("".join([sym + (str(num) if num > 1 else "") for sym, num in form.items()]))
+
     return " + ".join(parts)
 
 
@@ -30,11 +31,24 @@ def molecule(molecule: Union[str, plams.Molecule], mode: str = "unicode") -> str
     Parse and return a string containing a molecular formula that will show up properly in LaTeX, HTML or unicode.
 
     Args:
-        molecule: plams.Molecule object or a string that contains the molecular formula to be parsed. It can be either single molecule or a reaction. Molecules should be separated by '+' or '->'.
+        molecule: `plams.Molecule` object or a string that contains the molecular formula to be parsed. It can be either single molecule or a reaction. Molecules should be separated by '+' or '->'.
         mode: the formatter to convert the string to. Should be 'unicode', 'html', 'latex', 'pyplot'.
 
     Returns:
-        A string that is formatted to be rendered nicely in either HTML or LaTeX.
+        | A string that is formatted to be rendered nicely in either HTML or LaTeX.
+        | In the returned strings any numbers will be subscripted and `+`, `-`, `*` and `•` will be superscripted.
+        | For `latex` and `pyplot` modes we apply `\\mathrm` to letters.
+
+    Examples:
+        >>> molecule('C9H18NO*')
+        'C₉H₁₈NO•'
+
+        >>> molecule('C2H2 + CH3* -> C2H2CH3', mode='html')
+        'C<sub>2</sub>H<sub>2</sub> + CH<sub>3</sub><sup>•</sup> -> C<sub>2</sub>H<sub>2</sub>CH3'
+
+    .. seealso::
+        The :func:`parse_molecule` function is used to convert `plams.Molecule` objects to a molecular formula.
+
     """
     # to take care of plus-signs used to denote reactions we have to first split
     # the molstring into its parts.
@@ -43,6 +57,7 @@ def molecule(molecule: Union[str, plams.Molecule], mode: str = "unicode") -> str
     else:
         molstring = molecule
 
+    molstring = molstring.replace("*", "•")
     for part in molstring.split():
         # if part is only a plus-sign we skip this part. This is only true when the plus-sign
         # is used to denote a reaction
@@ -59,6 +74,10 @@ def molecule(molecule: Union[str, plams.Molecule], mode: str = "unicode") -> str
                 partret = partret.replace(num, f"<sub>{num}</sub>")
             if mode == "unicode":
                 partret = partret.replace(num, "₀₁₂₃₄₅₆₇₈₉"[int(num)])
+
+        for letter in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ":
+            if mode in ["latex", "pyplot"]:
+                partret = partret.replace(letter, f"\mathrm{{{letter}}}")
 
         # signs should be superscript
         for sign in "+-•":


### PR DESCRIPTION
You are now able to use asterisks to denote radicals. tcutility.formula will convert it to the right character.