### PR TITLE
Fixed an issue with wrongly named input file in ORCAJob call when not using temporary directories

### DIFF
--- a/src/tcutility/job/orca.py
+++ b/src/tcutility/job/orca.py
@@ -215,7 +215,7 @@ class ORCAJob(Job):
                 runf.write('rm -rf $TMPDIR\n')
                 
             else:
-                runf.write(f'{self.orca_path} {self.inputfile_path}.in\n')
+                runf.write(f'{self.orca_path} {self.inputfile_path}\n')
 
             runf.write('\n'.join(self._postambles))
 


### PR DESCRIPTION
I fixed an issue where the path to the input file is wrong in the runscript.