### PR TITLE
Fixed an issue where the `report.character` module was not importable

### DIFF
--- a/src/tcutility/report/__init__.py
+++ b/src/tcutility/report/__init__.py
@@ -1,0 +1,1 @@
+from . import character  # noqa


### PR DESCRIPTION
We should now be able to use the character module.