### PR TITLE
Added `_char_widths.txt` to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include src/tcutility/results/input_blocks
 include src/tcutility/data/*
 include src/tcutility/data/_atom_data_info/*.txt
 include src/tcutility/data/_atom_data_info/*.json
+include src/tcutility/report/_char_widths.txt


### PR DESCRIPTION
We were not exporting the character width files, so they could not be used by other programs.