### PR TITLE
Fixed a `timer` runtimewarning that occurs when a function was not called

### DIFF
--- a/src/tcutility/timer.py
+++ b/src/tcutility/timer.py
@@ -95,17 +95,18 @@ def print_timings():
     for name, parent, level in zip(names, parents, parent_levels):
         line = []
         line.append(name.replace(parent, ' > ' * level))  # function name
-        mean = np.mean(times_[name]["timings"])
-        total = np.sum(times_[name]["timings"])
         calls = times_[name].get("calls", 0)
         if calls == 0:
             line.append('')
             line.append('')
+            line.append('')
         else:
+            mean = np.mean(times_[name]["timings"])
+            total = np.sum(times_[name]["timings"])
             line.append(str(calls))
             line.append(f'{mean:.3f}')
+            line.append(f'{total:.3f}')
 
-        line.append(f'{total:.3f}')
         try:
             rel = sum(times_[name]["timings"])/sum(parent_times[parent]["timings"])*100
             rel_total = sum(times_[name]["timings"])/sum(parent_times["TOTAL"]["timings"])*100


### PR DESCRIPTION
In cases where a function that was tracked using the `tcutility.timer` class was not called during the runtime there would be a userwarning originating from a `numpy.mean` call. This PR fixes that.