### PR TITLE
`pathfunc` is now importable from `tcutility` directly

### DIFF
--- a/src/tcutility/__init__.py
+++ b/src/tcutility/__init__.py
@@ -14,4 +14,4 @@ def ensure_2d(x, transposed=False):
     return x
 
 
-from tcutility import constants, formula, geometry, log, molecule, results, slurm, data, analysis, report  # noqa: F401, E402
+from tcutility import constants, formula, geometry, log, molecule, results, slurm, data, analysis, report, pathfunc  # noqa: F401, E402


### PR DESCRIPTION
We were missing an import of `pathfunc` in the main `__init__.py`. This caused an error when importing it in a script.