### PR TITLE
Added option to perform electrostatic potential energy decomposition for `ADFFragmentJob`

### DIFF
--- a/examples/job/elstat_decomp.py
+++ b/examples/job/elstat_decomp.py
@@ -1,0 +1,62 @@
+from tcutility import job, results
+from scm import plams
+
+
+def load(xyz):
+	mol = plams.Molecule()
+	for line in xyz.strip().splitlines():
+		el, x, y, z = line.split()[:4]
+		mol.add_atom(plams.Atom(symbol=el, coords=(x, y, z)))
+	return mol
+
+mol = load("""
+N       0.00000000       0.00000000       0.81411087
+H       0.47592788      -0.82433127       1.14462651
+H       0.47592788       0.82433127       1.14462651
+H      -0.95185576       0.00000000       1.14462651
+B       0.00000000       0.00000000      -0.83480980
+H      -0.58140445      -1.00702205      -1.13772686
+H      -0.58140445       1.00702205      -1.13772686
+H       1.16280890       0.00000000      -1.13772686
+""")
+
+# optimize mol
+with job.ADFJob() as opt_job:
+	opt_job.rundir = 'Elstat'
+	opt_job.name = 'Opt'
+	opt_job.molecule(mol)
+	opt_job.optimization()
+	opt_job.functional('BP86')
+	opt_job.basis_set('TZP')
+	opt_job.quality('Good')
+
+
+with job.ADFFragmentJob(decompose_elstat=True) as frag_job:
+	frag_job.molecule(opt_job.output_mol_path)
+	frag_job.rundir = 'Elstat'
+	frag_job.name = 'EDA'
+	frag_job.functional('BP86')
+	frag_job.basis_set('TZP')
+	frag_job.quality('Good')
+
+	frag_job.add_fragment([1, 2, 3, 4], 'Donor')
+	frag_job.add_fragment([5, 6, 7, 8], 'Acceptor')
+
+res_main = results.read('Elstat/EDA/complex_STOFIT')
+print(res_main.properties.energy.elstat)
+
+
+res_acceptor = results.read('Elstat/EDA/complex_Acceptor_NoElectrons')
+print(res_acceptor.properties.energy.elstat)
+
+
+res_donor = results.read('Elstat/EDA/complex_Donor_NoElectrons')
+print(res_donor.properties.energy.elstat)
+
+
+print('Electrostatic Potential Terms:')
+print(f'  e–e repulsion: 				   {res_main.properties.energy.elstat.Vee: 10.0f} kcal/mol')
+print(f'  N–N repulsion: 				   {res_main.properties.energy.elstat.Vnn: 10.0f} kcal/mol')
+print(f'  e(Donor)–N(Acceptor) attraction: {res_acceptor.properties.energy.elstat.Ven: 10.0f} kcal/mol')
+print(f'  N(Donor)–e(Acceptor) attraction: {res_donor.properties.energy.elstat.Ven: 10.0f} kcal/mol')
+print(f'  total: 						   {res_main.properties.energy.elstat.total: 10.1f} kcal/mol')

--- a/src/tcutility/molecule.py
+++ b/src/tcutility/molecule.py
@@ -96,9 +96,9 @@ def load(path) -> plams.Molecule:
     for line in atom_lines:
         # parse every atom first
         symbol, x, y, z, *args = line.split()
-        atom = plams.Atom(symbol=symbol, coords=(float(x), float(y), float(z)))
-        atom.flags = parse_flags(args)
-        mol.add_atom(atom)
+        at = plams.Atom(symbol=symbol, coords=(float(x), float(y), float(z)))
+        at.flags = parse_flags(args)
+        mol.add_atom(at)
 
     # after the atoms we parse the flags for the molecule
     flag_lines = lines[natoms + 2 :]
@@ -197,12 +197,12 @@ def guess_fragments(mol: plams.Molecule) -> Dict[str, plams.Molecule]:
         return result.Result(fragment_mols)
 
     # second method, check if the atoms have a frag= flag defined
-    fragment_names = set(atom.flags.get("frag") for atom in mol)
+    fragment_names = set(at.flags.get("frag") for at in mol)
     if len(fragment_names) > 0:
         fragment_mols = {name: plams.Molecule() for name in fragment_names}
-        for atom in mol:
+        for at in mol:
             # get the fragment the atom belongs to and add it to the list
-            fragment_mols[atom.flags.get("frag")].add_atom(atom)
+            fragment_mols[at.flags.get("frag")].add_atom(at)
 
         for frag in fragment_names:
             fragment_mols[frag].flags = {"tags": set()}
@@ -231,9 +231,9 @@ def _xyz_format(mol: plams.Molecule, include_n_atoms: bool = True) -> str:
     """
     n_atoms = len(mol.atoms)
     if include_n_atoms:
-        return f"{n_atoms}\n" + "\n".join([f"{atom.symbol:6s}{atom.x:16.8f}{atom.y:16.8f}{atom.z:16.8f}" for atom in mol.atoms])
+        return f"{n_atoms}\n" + "\n".join([f"{at.symbol:6s}{at.x:16.8f}{at.y:16.8f}{at.z:16.8f}" for at in mol.atoms])
 
-    return "\n".join([f"{atom.symbol:6s}{atom.x:16.8f}{atom.y:16.8f}{atom.z:16.8f}" for atom in mol.atoms])
+    return "\n".join([f"{at.symbol:6s}{at.x:16.8f}{at.y:16.8f}{at.z:16.8f}" for at in mol.atoms])
 
 
 def _amv_format(mol: plams.Molecule, step: int, energy: Union[float, None] = None) -> str:
@@ -248,8 +248,8 @@ def _amv_format(mol: plams.Molecule, step: int, energy: Union[float, None] = Non
 
     If no energy is provided, the energy is not included in the string representation"""
     if energy is None:
-        return f"Geometry {step}\n" + "\n".join([f"{atom.symbol:6s}{atom.x:16.8f}{atom.y:16.8f}{atom.z:16.8f}" for atom in mol.atoms])
-    return f"Geometry {step}, Energy: {energy} Ha\n" + "\n".join([f"{atom.symbol:6s}{atom.x:16.8f}{atom.y:16.8f}{atom.z:16.8f}" for atom in mol.atoms])
+        return f"Geometry {step}\n" + "\n".join([f"{at.symbol:6s}{at.x:16.8f}{at.y:16.8f}{at.z:16.8f}" for at in mol.atoms])
+    return f"Geometry {step}, Energy: {energy} Ha\n" + "\n".join([f"{at.symbol:6s}{at.x:16.8f}{at.y:16.8f}{at.z:16.8f}" for at in mol.atoms])
 
 
 def write_mol_to_xyz_file(mols: Union[List[plams.Molecule], plams.Molecule], filename: Union[str, pl.Path], include_n_atoms: bool = False) -> None:
@@ -284,9 +284,9 @@ def save(mol: plams.Molecule, path: str, comment: str = None):
     comment = comment or mol.comment if hasattr(mol, "comment") else ""
     with open(path, "w+") as f:
         f.write(f"{len(mol.atoms)}\n{comment}\n")
-        for atom in mol.atoms:
+        for at in mol.atoms:
             flags_str = ""
-            flags = atom.flags if hasattr(atom, "flags") else {}
+            flags = at.flags if hasattr(at, "flags") else {}
             for key, value in flags.items():
                 if key == "tags":
                     if len(value) > 0:
@@ -296,7 +296,7 @@ def save(mol: plams.Molecule, path: str, comment: str = None):
                 else:
                     flags_str += f"{key}={value} "
 
-            f.write(f"{atom.symbol}\t{atom.coords[0]: .10f}\t{atom.coords[1]: .10f}\t{atom.coords[2]: .10f}\t{flags_str}\n")
+            f.write(f"{at.symbol}\t{at.coords[0]: .10f}\t{at.coords[1]: .10f}\t{at.coords[2]: .10f}\t{flags_str}\n")
 
         f.write("\n")
 

--- a/src/tcutility/molecule.py
+++ b/src/tcutility/molecule.py
@@ -5,6 +5,14 @@ from scm import plams
 
 from tcutility import ensure_list
 from tcutility.results import result
+from tcutility.data import atom
+
+
+def number_of_electrons(mol: plams.Molecule) -> int:
+    nel = 0
+    for at in mol:
+        nel += atom.atom_number(at.symbol)
+    return nel
 
 
 def parse_str(s: str):

--- a/src/tcutility/results/adf.py
+++ b/src/tcutility/results/adf.py
@@ -164,6 +164,9 @@ def get_properties(info: Result) -> Result:
 
             - **energy.bond (float)** – bonding energy (|kcal/mol|).
             - **energy.elstat.total (float)** – total electrostatic potential (|kcal/mol|).
+            - **energy.elstat.Vee (float)** – electron-electron repulsive term of the electrostatic potential (|kcal/mol|).
+            - **energy.elstat.Ven (float)** – electron-nucleus attractive term of the electrostatic potential (|kcal/mol|).
+            - **energy.elstat.Vnn (float)** – nucleus-nucleus repulsive term of the electrostatic potential (|kcal/mol|).
             - **energy.orbint.total (float)** – total orbital interaction energy containing contributions from each symmetry label and correction energy(|kcal/mol|).
             - **energy.orbint.{symmetry label} (float)** – orbital interaction energy from a specific symmetry label (|kcal/mol|).
             - **energy.orbint.correction (float)** - orbital interaction correction energy, the difference between the total and the sum of the symmetrized interaction energies (|kcal/mol|)
@@ -198,7 +201,29 @@ def get_properties(info: Result) -> Result:
 
     # read energies (given in Ha in rkf files)
     ret.energy.bond = reader_adf.read("Energy", "Bond Energy") * constants.HA2KCALMOL
-    ret.energy.elstat = reader_adf.read("Energy", "elstat") * constants.HA2KCALMOL
+
+    # total electrostatic potential
+    ret.energy.elstat.total = reader_adf.read("Energy", "elstat") * constants.HA2KCALMOL
+
+    # we can further decompose elstat if it was enabled
+    if info.files.out:
+        with open(info.files.out) as output:
+            lines = output.readlines()
+
+        skip_next = -1
+        for line in lines:
+            if "Electrostatic Interaction Energies" in line:
+                skip_next = 4
+                continue
+            if skip_next == 0:
+                f1, f2, Vee, Ven, Vnn, total = line.strip().split()
+                ret.energy.elstat.Vee = float(Vee) * constants.HA2KCALMOL
+                ret.energy.elstat.Ven = float(Ven) * constants.HA2KCALMOL
+                ret.energy.elstat.Vnn = float(Vnn) * constants.HA2KCALMOL
+            skip_next -= 1
+
+
+    # print(info.files)
 
 
     # read the total orbital interaction energy

--- a/src/tcutility/results/adf.py
+++ b/src/tcutility/results/adf.py
@@ -163,7 +163,7 @@ def get_properties(info: Result) -> Result:
         :Result object containing properties from the ADF calculation:
 
             - **energy.bond (float)** – bonding energy (|kcal/mol|).
-            - **energy.elstat (float)** – total electrostatic potential (|kcal/mol|).
+            - **energy.elstat.total (float)** – total electrostatic potential (|kcal/mol|).
             - **energy.orbint.total (float)** – total orbital interaction energy containing contributions from each symmetry label and correction energy(|kcal/mol|).
             - **energy.orbint.{symmetry label} (float)** – orbital interaction energy from a specific symmetry label (|kcal/mol|).
             - **energy.orbint.correction (float)** - orbital interaction correction energy, the difference between the total and the sum of the symmetrized interaction energies (|kcal/mol|)

--- a/src/tcutility/results/ams.py
+++ b/src/tcutility/results/ams.py
@@ -71,7 +71,7 @@ def get_calc_files(calc_dir: str) -> dict:
             f = ".".join(parts[1:]).replace("logfile", "log")
             ret[f] = os.path.abspath(file)
 
-        if file.endswith(".out") and not "CreateAtoms" in file:
+        if file.endswith(".out") and "CreateAtoms" not in file:
             ret["out"] = os.path.abspath(file)
 
     return ret

--- a/src/tcutility/results/ams.py
+++ b/src/tcutility/results/ams.py
@@ -277,10 +277,7 @@ def _get_fragment_indices_from_input_order(results_type) -> arrays.Array1D:
     """Function to get the fragment indices from the input order. This is needed because the fragment indices are stored in internal order in the rkf file."""
     frag_indices = np.array(results_type.read("Geometry", "fragment and atomtype index")).reshape(2, -1)  # 1st row: Fragment index; 2nd row atomtype index
     atom_order = np.array(results_type.read("Geometry", "atom order index")).reshape(2, -1)  # 1st row: input order; 2nd row: internal order
-    combined = np.concatenate((frag_indices, atom_order), axis=0)
-    sorted_by_input_order = np.array(sorted(combined.T, key=lambda x: x[2]))  # sort the fragment indices by input order
-    frag_order = sorted_by_input_order[:, 0]
-    return frag_order
+    return frag_indices[0][atom_order[0] - 1]
 
 
 # ------------------------ Molecule -------------------------- #

--- a/src/tcutility/results/ams.py
+++ b/src/tcutility/results/ams.py
@@ -71,6 +71,9 @@ def get_calc_files(calc_dir: str) -> dict:
             f = ".".join(parts[1:]).replace("logfile", "log")
             ret[f] = os.path.abspath(file)
 
+        if file.endswith(".out") and not "CreateAtoms" in file:
+            ret["out"] = os.path.abspath(file)
+
     return ret
 
 

--- a/test/test_vdd_analysis.py
+++ b/test/test_vdd_analysis.py
@@ -65,7 +65,7 @@ def vdd_manager_geo_nosym():
 
 def test_get_fragment_indices_from_input_order_disordered(kfreader_fa_disordered_fragindices_cs):
     frag_indices = ams._get_fragment_indices_from_input_order(kfreader_fa_disordered_fragindices_cs)
-    assert np.array_equal(frag_indices, np.array([1, 1, 1, 2, 2, 2, 2, 2, 2, 1, 1]))
+    assert np.array_equal(frag_indices, np.array([1, 1, 1, 2, 2, 2, 1, 1, 2, 2, 2]))
 
 
 def test_get_fragment_indices_from_input_order_ordered(kfreader_fa_ordered_fragindices_cs):


### PR DESCRIPTION
We added the option `decompose_elstat`  to the constructor of `ADFFragmentJob` class. It will perform extra calculations that allow you to obtain energy terms that constitute the electrostatic potential energy. These are the electron–electron repulsion, electron–nucleus attraction and nucleus–nucleus repulsion. This decomposition further decomposes the electron–nucleus attraction into the fragment terms. It does so by removing the electrons of one fragment and interacting it with the other fragment.
We also added the new electrostatic terms to the `Result.properties.energy.elstat` object, specifically the new `total`, `Vee`, `Ven` and `Vnn` terms.