### PR TITLE
Fixed a typo that was causing an issue when running jobs

### DIFF
--- a/src/tcutility/job/generic.py
+++ b/src/tcutility/job/generic.py
@@ -204,7 +204,7 @@ class Job:
         else:
             os_name = get_os_name()
 
-            if os_name == OSName.Windows:
+            if os_name == OSName.WINDOWS:
                 raise TCJobError("Generic Job", "Running jobs on Windows is not supported.")
 
             # if we are not using slurm, we can execute the file. For this we need special permissions, so we have to set that first.


### PR DESCRIPTION
There was an error caused by a typo when checking the OSName.