### PR TITLE
Fixes for electrostatic decomposition analyses

### DIFF
--- a/examples/job/elstat_decomp.py
+++ b/examples/job/elstat_decomp.py
@@ -3,11 +3,11 @@ from scm import plams
 
 
 def load(xyz):
-	mol = plams.Molecule()
-	for line in xyz.strip().splitlines():
-		el, x, y, z = line.split()[:4]
-		mol.add_atom(plams.Atom(symbol=el, coords=(x, y, z)))
-	return mol
+    mol = plams.Molecule()
+    for line in xyz.strip().splitlines():
+        el, x, y, z = line.split()[:4]
+        mol.add_atom(plams.Atom(symbol=el, coords=(x, y, z)))
+    return mol
 
 mol = load("""
 N       0.00000000       0.00000000       0.81411087
@@ -22,25 +22,29 @@ H       1.16280890       0.00000000      -1.13772686
 
 # optimize mol
 with job.ADFJob() as opt_job:
-	opt_job.rundir = 'Elstat'
-	opt_job.name = 'Opt'
-	opt_job.molecule(mol)
-	opt_job.optimization()
-	opt_job.functional('BP86')
-	opt_job.basis_set('TZP')
-	opt_job.quality('Good')
+    opt_job.rundir = 'Elstat'
+    opt_job.name = 'Opt'
+    opt_job.molecule(mol)
+    opt_job.optimization()
+    opt_job.functional('BP86')
+    opt_job.basis_set('TZP')
+    opt_job.quality('Good')
+    opt_job.sbatch(p='tc', N=1, t='240:00:00', ntasks_per_node=8)
 
 
 with job.ADFFragmentJob(decompose_elstat=True) as frag_job:
-	frag_job.molecule(opt_job.output_mol_path)
-	frag_job.rundir = 'Elstat'
-	frag_job.name = 'EDA'
-	frag_job.functional('BP86')
-	frag_job.basis_set('TZP')
-	frag_job.quality('Good')
+    frag_job.molecule(opt_job.output_mol_path)
+    frag_job.rundir = 'Elstat'
+    frag_job.name = 'EDA'
+    frag_job.functional('BP86')
+    frag_job.basis_set('TZP')
+    frag_job.quality('Good')
+    frag_job.settings.input.adf.PRINT += ' EKin'
 
-	frag_job.add_fragment([1, 2, 3, 4], 'Donor')
-	frag_job.add_fragment([5, 6, 7, 8], 'Acceptor')
+    frag_job.add_fragment([1, 2, 3, 4], 'Donor')
+    frag_job.add_fragment([5, 6, 7, 8], 'Acceptor')
+    frag_job.sbatch(p='tc', N=1, t='240:00:00', ntasks_per_node=8)
+
 
 res_main = results.read('Elstat/EDA/complex_STOFIT')
 print(res_main.properties.energy.elstat)
@@ -55,8 +59,8 @@ print(res_donor.properties.energy.elstat)
 
 
 print('Electrostatic Potential Terms:')
-print(f'  e–e repulsion: 				   {res_main.properties.energy.elstat.Vee: 10.0f} kcal/mol')
-print(f'  N–N repulsion: 				   {res_main.properties.energy.elstat.Vnn: 10.0f} kcal/mol')
+print(f'  e–e repulsion:                   {res_main.properties.energy.elstat.Vee: 10.0f} kcal/mol')
+print(f'  N–N repulsion:                   {res_main.properties.energy.elstat.Vnn: 10.0f} kcal/mol')
 print(f'  e(Donor)–N(Acceptor) attraction: {res_acceptor.properties.energy.elstat.Ven: 10.0f} kcal/mol')
 print(f'  N(Donor)–e(Acceptor) attraction: {res_donor.properties.energy.elstat.Ven: 10.0f} kcal/mol')
-print(f'  total: 						   {res_main.properties.energy.elstat.total: 10.1f} kcal/mol')
+print(f'  total:                           {res_main.properties.energy.elstat.total: 10.1f} kcal/mol')

--- a/src/tcutility/__init__.py
+++ b/src/tcutility/__init__.py
@@ -14,4 +14,4 @@ def ensure_2d(x, transposed=False):
     return x
 
 
-from tcutility import constants, formula, geometry, log, molecule, results, slurm, data, analysis, report, pathfunc  # noqa: F401, E402
+from tcutility import job, constants, formula, geometry, log, molecule, results, slurm, data, analysis, report, pathfunc  # noqa: F401, E402

--- a/src/tcutility/analysis/pyfrag.py
+++ b/src/tcutility/analysis/pyfrag.py
@@ -1,0 +1,116 @@
+import tcutility
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+import pyfmo
+
+
+def read(path):
+    return PyFragResult(path)
+
+
+class PyFragResult:
+    def __init__(self, path):
+        self.path = path
+
+        self._frag_results = {}
+        self._step_results = []
+        self._order = []
+        self._mask = []
+
+        self._load()
+
+    def _load(self):
+        for frag_path, info in tcutility.pathfunc.match(self.path, 'frag_{frag}').items():
+            self._frag_results[info.frag] = tcutility.results.read(frag_path)
+
+        for step_path, info in tcutility.pathfunc.match(self.path, 'Step.{step}', sort_by='step').items():
+            self._step_results.append({})
+            for dir_name in os.listdir(step_path):
+                p = os.path.join(step_path, dir_name)
+                res = tcutility.results.read(p)
+                self._step_results[-1][dir_name] = res
+
+            self._order.append(int(info.step.removeprefix('0')))
+            self._mask.append(True)
+
+        self._mask = np.array(self._mask)
+
+    def get_property(self, key: str, calc: str = 'complex'):
+        p = np.array([res[calc].properties.get_multi_key(key) for res in self._step_results])
+        return p[self._order][self._mask[self._order]]
+
+    @property
+    def fragments(self):
+        return list(self._frag_results.keys())
+
+    def __len__(self):
+        return sum(self._mask)
+
+    def get_geometry(self, *args, **kwargs):
+        calc = kwargs.pop('calc', 'complex')
+        g = np.array([tcutility.geometry.parameter(res[calc].molecule.input, *args, **kwargs) for res in self._step_results])
+        return g[self._order][self._mask[self._order]]
+
+    def sort_by(self, val: str or list, calc: str = 'complex'):
+        if isinstance(val, str):
+            val = self.get_property(val, calc=calc)
+        self._order = np.argsort(val)
+
+    def set_mask(self, mask: list):
+        self._mask = mask
+
+    @property
+    def ts_idx(self):
+        energies = self.get_property('energy.bond', 'complex')
+        highest = -float('inf')
+        for i in range(1, len(self) - 1):
+            if energies[i-1] < energies[i] and energies[i] < energies[i+1]:
+                return i
+
+    def total_energy(self):
+        return self.interaction_energy() + self.strain_energy()
+
+    def interaction_energy(self):
+        return self.get_property('energy.bond', 'complex')
+
+    def strain_energy(self, fragment: str = None):
+        if fragment is None:
+            t = 0
+            for frag in self.fragments:
+                t += self.strain_energy(frag)
+            return t
+
+        return self.get_property('energy.bond', f'frag_{fragment}') - self._frag_results[fragment].properties.energy.bond
+
+    def overlap(self, orb1, orb2, calc: str = 'complex'):
+        S = np.array([orb.sfos[orb1] @ orb.sfos[orb2] for orb in self.orbs(calc)])
+        return S[self._order][self._mask[self._order]]
+
+    def sfo_coefficient(self, sfo, mo, calc: str = 'complex'):
+        C = np.array([orb.sfos[sfo].coefficient(orb.mos[mo]) for orb in self.orbs(calc)])
+        return C[self._order][self._mask[self._order]]
+
+    @tcutility.cache.cache
+    def orbs(self, calc: str = 'complex'):
+        return [pyfmo.orbitals2.objects.Orbitals(res[calc].files['adf.rkf']) for res in self._step_results]
+
+if __name__ == '__main__':
+    res = read('/Users/yumanhordijk/PhD/Projects/RadicalAdditionASMEDA/data/DFT/TS_C_O/PyFrag_OLYP_TZ2P')
+    res.sort_by(res.get_geometry(0, 1))
+    res.set_mask(res.get_geometry(0, 1) < res.get_geometry(0, 1)[res.ts_idx])
+    # plt.plot(res.get_geometry(0, 1), res.total_energy())
+    # plt.plot(res.get_geometry(0, 1), res.interaction_energy())
+    # plt.plot(res.get_geometry(0, 1), res.strain_energy())
+    # plt.xlim(3, 2.2)
+    # plt.show()
+
+    plt.plot(res.get_geometry(0, 1), abs(res.overlap('Substrate(7A_A)', 'Methyl(5A_A)')))
+    plt.plot(res.get_geometry(0, 1), abs(res.overlap('Substrate(4A_A)', 'Methyl(5A_A)')))
+    plt.plot(res.get_geometry(0, 1), abs(res.overlap('Substrate(3A_A)', 'Methyl(5A_A)')))
+    # Px_coeff = res.sfo_coefficient('C(1P:x)', '7A_A', calc='frag_Substrate')
+    # Py_coeff = res.sfo_coefficient('C(1P:y)', '7A_A', calc='frag_Substrate')
+    # Pz_coeff = res.sfo_coefficient('C(1P:z)', '7A_A', calc='frag_Substrate')
+    # plt.plot(res.get_geometry(0, 1), np.sqrt(Px_coeff**2 + Py_coeff**2 + Pz_coeff**2))
+    plt.xlim(3, 2.2)
+    plt.show()

--- a/src/tcutility/cli_scripts/geo.py
+++ b/src/tcutility/cli_scripts/geo.py
@@ -1,18 +1,18 @@
 """ Module containing functions for calculating geometrical parameters for molecules """
 import argparse
-from tcutility import geometry, molecule
+from tcutility import geometry, molecule, results
 
 
 def create_subparser(parent_parser: argparse.ArgumentParser):
     desc = """Calculate geometrical parameters for atoms at the provided indices.
 
-For 1 index this program returns the cartesian coordinate for this atom. 
-For 2 indices return bond length between atoms. 
-For 3 indices return bond angle, with the second index being the central atom. 
-For 4 indices return dihedral angle by calculating the angle between normal vectors described by atoms at indices 1-2-3 and indices 2-3-4. 
+For 1 index this program returns the cartesian coordinate for this atom.
+For 2 indices return bond length between atoms.
+For 3 indices return bond angle, with the second index being the central atom.
+For 4 indices return dihedral angle by calculating the angle between normal vectors described by atoms at indices 1-2-3 and indices 2-3-4.
 If the -p/--pyramidal flag is turned on it calculates 360° - ang1 - ang2 - ang3, where ang1, ang2 and ang3 are the angles described by indices 2-1-3, 3-1-4 and 4-1-2 respectively.
 """
-    subparser = parent_parser.add_parser('geo', help=desc, description=desc)
+    subparser = parent_parser.add_parser('geo', help=desc, description=desc, formatter_class=argparse.RawTextHelpFormatter)
     subparser.add_argument("xyzfile",
                            type=str,
                            nargs=1,
@@ -28,7 +28,10 @@ If the -p/--pyramidal flag is turned on it calculates 360° - ang1 - ang2 - ang3
 
 
 def main(args: argparse.Namespace):
-    mol = molecule.load(args.xyzfile[0])
+    try:
+        mol = molecule.load(args.xyzfile[0])
+    except IsADirectoryError:
+        mol = results.read(args.xyzfile[0]).molecule.output
     indices = [int(i) - 1 for i in args.atom_indices]
 
     assert 1 <= len(indices) <= 4, f"Number of indices must be 1, 2, 3 or 4, not {len(indices)}"

--- a/src/tcutility/cli_scripts/resize_figures.py
+++ b/src/tcutility/cli_scripts/resize_figures.py
@@ -1,0 +1,39 @@
+""" Module containing CLI functionality for resizing pictures containing molecules """
+import argparse
+from tcutility import report
+import os
+
+
+def create_subparser(parent_parser: argparse.ArgumentParser):
+    desc = """Resize images containing molecules.
+
+This CLI-program resizes images in a directory based on detected circles. It will ensure the selected circles are placed at the same location and are also resized to be the same size.
+When starting the program it will show you for each image numbered detected atoms. 
+Entering the desired number into the CLI will select it for resizing. If you do not enter a number, the figure will be ignored for further processing.
+New images will be written to the folder postpended with _fixed.
+    """
+    subparser = parent_parser.add_parser('resize', help=desc, description=desc, formatter_class=argparse.RawTextHelpFormatter)
+    subparser.add_argument("folder",
+                           type=str,
+                           nargs=1,
+                           help="A folder containing images containing molecules which will be resized.")
+    subparser.add_argument("-p", "--padding",
+                           help="""The amount of padding to add to the resized figures.
+If given an integer we use pixel padding. E.g. -p 50 will add a padding of 50 pixels.
+Add a %%-sign to use relative padding. E.g. -p 10%% will add a padding of 10%%.""",
+                           default='10%')
+
+
+def main(args: argparse.Namespace):
+    circle_numbers = {}
+    for img_path in os.listdir(args.folder[0]):
+        report.figure_resizer.get_data(os.path.join(args.folder[0], img_path), plot=True)
+        circle = input(f'Select circle for {img_path}, leave empty to skip: ')
+        if circle == '':
+            continue
+
+        circle_numbers[img_path] = int(circle)
+
+    report.figure_resizer.resize(args.folder[0], circle_numbers, padding=args.padding)
+
+    # print(args.folder)

--- a/src/tcutility/cli_scripts/tcparser.py
+++ b/src/tcutility/cli_scripts/tcparser.py
@@ -1,4 +1,4 @@
-from tcutility.cli_scripts import read, job_script, concatenate_irc, cite, geo
+from tcutility.cli_scripts import read, job_script, concatenate_irc, cite, geo, resize_figures
 
 # to add a script:
 # 1. Add a create_subparser function and main function to your script.
@@ -10,6 +10,7 @@ sub_programs = {
     "concat-irc": concatenate_irc,
     "cite": cite,
     "geo": geo,
+    "resize": resize_figures,
 }
 
 

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -650,7 +650,6 @@ class ADFFragmentJob(ADFJob):
             self.settings.input.ams.EngineDebugging.pop('AlwaysClaimSuccess', None)
             self.settings.input.adf.pop('fragments', None)
             for frag, frag_job in self.child_jobs.items():
-                other_jobs = [job for other_frag, job in self.child_jobs.items() if other_frag != frag]
                 atoms = [atom for job in self.child_jobs.values() for atom in job._molecule]
 
                 # in the parent job the atoms should have the region and adf.f defined as options

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -447,6 +447,7 @@ class ADFFragmentJob(ADFJob):
                 log.flow()
             else:
                 log.flow(log.Emojis.good + ' Submitting', ['straight', 'end'])
+                [child._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                 child.run()
                 self.dependency(child)
                 log.flow(f'SlurmID:  {child.slurm_job_id}', ['straight', 'skip', 'end'])
@@ -471,6 +472,7 @@ class ADFFragmentJob(ADFJob):
                     log.flow()
                 else:
                     log.flow(log.Emojis.good + ' Submitting', ['straight', 'end'])
+                    [child_STOFIT._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                     child_STOFIT.run()
                     self.dependency(child_STOFIT)
                     log.flow(f'SlurmID:  {child_STOFIT.slurm_job_id}', ['straight', 'skip', 'end'])
@@ -496,6 +498,7 @@ class ADFFragmentJob(ADFJob):
                     log.flow()
                 else:
                     log.flow(log.Emojis.good + ' Submitting', ['straight', 'end'])
+                    [child_NoElectrons._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                     child_NoElectrons.run()
                     self.dependency(child_NoElectrons)
                     log.flow(f'SlurmID:  {child_NoElectrons.slurm_job_id}', ['straight', 'skip', 'end'])

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -299,6 +299,12 @@ class ADFFragmentJob(ADFJob):
         self.child_jobs[name].molecule(mol)
         self.child_jobs[name].charge(charge)
         self.child_jobs[name].spin_polarization(spin_polarization)
+        self.child_jobs[name]._sbatch.pop('D', None)
+        self.child_jobs[name]._sbatch.pop('chdir', None)
+        self.child_jobs[name]._sbatch.pop('J', None)
+        self.child_jobs[name]._sbatch.pop('job_name', None)
+        self.child_jobs[name]._sbatch.pop('o', None)
+        self.child_jobs[name]._sbatch.pop('output', None)
         setattr(self, name, self.child_jobs[name])
 
         if not add_frag_to_mol:

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -476,8 +476,8 @@ class ADFFragmentJob(ADFJob):
             # recast the plams.Settings object into a Result object as that is what run expects
             child.settings = results.Result(child_setts[child_name])
             log.flow(f'Fragment ({i}/{len(self.child_jobs)}) {child_name} [{formula.molecule(child._molecule)}]', ['split'])
-            log.flow(f'Charge:            {child.settings.input.ams.System.charge}', ['straight', 'straight'])
-            log.flow(f'Spin-Polarization: {child.settings.input.adf.SpinPolarization}', ['straight', 'straight'])
+            log.flow(f'Charge:            {child.settings.input.ams.System.charge or 0}', ['straight', 'straight'])
+            log.flow(f'Spin-Polarization: {child.settings.input.adf.SpinPolarization or 0}', ['straight', 'straight'])
             log.flow(f'Work dir:          {child.workdir}', ['straight', 'straight'])
             if child.can_skip():
                 log.flow(log.Emojis.warning + " Already ran, skipping", ["straight", "end"])
@@ -500,8 +500,8 @@ class ADFFragmentJob(ADFJob):
                 child_STOFIT.settings.input.adf.BeckeGrid.Quality = "Excellent"
 
                 log.flow(f'Fragment ({i}/{len(self.child_jobs)}) {child_name} [{formula.molecule(child._molecule)}] with STOFIT', ['split'])
-                log.flow(f'Charge:            {child_STOFIT.settings.input.ams.System.charge}', ['straight', 'straight'])
-                log.flow(f'Spin-Polarization: {child_STOFIT.settings.input.adf.SpinPolarization}', ['straight', 'straight'])
+                log.flow(f'Charge:            {child_STOFIT.settings.input.ams.System.charge or 0}', ['straight', 'straight'])
+                log.flow(f'Spin-Polarization: {child_STOFIT.settings.input.adf.SpinPolarization or 0}', ['straight', 'straight'])
                 log.flow(f'Work dir:          {child_STOFIT.workdir}', ['straight', 'straight'])
 
                 if child_STOFIT.can_skip():
@@ -526,8 +526,8 @@ class ADFFragmentJob(ADFJob):
                 child_NoElectrons.settings.input.adf.BeckeGrid.Quality = "Excellent"
 
                 log.flow(f'Fragment ({i}/{len(self.child_jobs)}) {child_name} [{formula.molecule(child._molecule)}] without Electrons', ['split'])
-                log.flow(f'Charge:            {child_NoElectrons.settings.input.ams.System.charge}', ['straight', 'straight'])
-                log.flow(f'Spin-Polarization: {child_NoElectrons.settings.input.adf.SpinPolarization}', ['straight', 'straight'])
+                log.flow(f'Charge:            {child_NoElectrons.settings.input.ams.System.charge or 0}', ['straight', 'straight'])
+                log.flow(f'Spin-Polarization: {child_NoElectrons.settings.input.adf.SpinPolarization or 0}', ['straight', 'straight'])
                 log.flow(f'Work dir:          {child_NoElectrons.workdir}', ['straight', 'straight'])
                 
                 if child_NoElectrons.can_skip():

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -656,7 +656,7 @@ class DensfJob(Job):
         elif self.settings.ADFFile != orbital.kfpath:
             raise TCJobError(job_class=self.__class__.__name__, message="RKF file that was previously set not the same as the one being set now. Please start a new job for each RKF file.")
 
-    def density(self, orbitals: 'pyfmo.orbitals.Orbitals'):
+    def density(self, orbitals: 'pyfmo.orbitals.Orbitals'):  # noqa: F821
         import pyfmo
 
         # check if the ADFFile is the same for all added orbitals

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -482,7 +482,7 @@ class ADFFragmentJob(ADFJob):
                 child_NoElectrons.name += '_NoElectrons'
                 elstat_jobs[child_NoElectrons.name] = child_NoElectrons
                 child_NoElectrons.settings.input.adf.STOFIT = ''
-                child_NoElectrons.settings.input.adf.PRINT = +' Elstat'
+                child_NoElectrons.settings.input.adf.PRINT += ' Elstat'
                 child_NoElectrons.charge(molecule.number_of_electrons(child_NoElectrons._molecule))
                 child_NoElectrons.spin_polarization(0)
                 child_NoElectrons.settings.input.adf.pop("NumericalQuality")

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -660,8 +660,6 @@ class DensfJob(Job):
             raise TCJobError(job_class=self.__class__.__name__, message="RKF file that was previously set not the same as the one being set now. Please start a new job for each RKF file.")
 
     def density(self, orbitals: 'pyfmo.orbitals.Orbitals'):  # noqa: F821
-        import pyfmo
-
         # check if the ADFFile is the same for all added orbitals
         if self.settings.ADFFile is None:
             self.settings.ADFFile = orbitals.kfpath

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -458,7 +458,7 @@ class ADFFragmentJob(ADFJob):
                 child_STOFIT.name += '_STOFIT'
                 elstat_jobs[child_STOFIT.name] = child_STOFIT
                 child_STOFIT.settings.input.adf.STOFIT = ''
-                child_STOFIT.settings.input.adf.PRINT = 'FmatSFO Elstat'
+                child_STOFIT.settings.input.adf.PRINT += ' Elstat'
                 child_STOFIT.settings.input.adf.pop("NumericalQuality")
                 child_STOFIT.settings.input.adf.BeckeGrid.Quality = "Excellent"
 
@@ -482,7 +482,7 @@ class ADFFragmentJob(ADFJob):
                 child_NoElectrons.name += '_NoElectrons'
                 elstat_jobs[child_NoElectrons.name] = child_NoElectrons
                 child_NoElectrons.settings.input.adf.STOFIT = ''
-                child_NoElectrons.settings.input.adf.PRINT = 'FmatSFO Elstat'
+                child_NoElectrons.settings.input.adf.PRINT = +' Elstat'
                 child_NoElectrons.charge(molecule.number_of_electrons(child_NoElectrons._molecule))
                 child_NoElectrons.spin_polarization(0)
                 child_NoElectrons.settings.input.adf.pop("NumericalQuality")
@@ -564,7 +564,7 @@ class ADFFragmentJob(ADFJob):
             for frag_name in frag_names:
                 self.settings.input.adf.fragments[frag_name + '_STOFIT'] = j(elstat_jobs['frag_' + frag_name + '_STOFIT'].workdir, 'adf.rkf')
             self.settings.input.adf.STOFIT = ''
-            self.settings.input.adf.PRINT = 'FmatSFO Elstat'
+            self.settings.input.adf.PRINT += ' Elstat'
             [self._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
             log.flow(log.Emojis.good + ' Submitting complex with STOFIT', ['split'])
             super().run()

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -636,6 +636,9 @@ class DensfJob(Job):
         spell_check.check(size, ["coarse", "medium", "fine"], ignore_case=True)
         self.settings.grid = size
 
+    def grid(self, args):
+        self.settings.grid = '\n' + '\n'.join(args)
+
     def orbital(self, orbital: "pyfmo.orbitals.sfo.SFO" or "pyfmo.orbitals.mo.MO"):  # noqa: F821
         """
         Add a PyOrb orbital for Densf to calculate.
@@ -694,7 +697,8 @@ class DensfJob(Job):
                 inpf.write(line + '\n')
 
             # cuboutput prefix is always the original run directory containing the adf.rkf file and includes the grid size
-            inpf.write(f"CUBOUTPUT {os.path.split(self.settings.ADFFile)[0]}/{self.settings.grid}\n")
+            outname = self.settings.grid if self.settings.grid.lower() in ['coarse', 'medium', 'fine'] else 'custom_grid'
+            inpf.write(f"CUBOUTPUT {os.path.split(self.settings.ADFFile)[0]}/{outname}\n")
             inpf.write("eor\n")
 
         # the runfile should simply execute the input file.

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -299,12 +299,6 @@ class ADFFragmentJob(ADFJob):
         self.child_jobs[name].molecule(mol)
         self.child_jobs[name].charge(charge)
         self.child_jobs[name].spin_polarization(spin_polarization)
-        self.child_jobs[name]._sbatch.pop('D', None)
-        self.child_jobs[name]._sbatch.pop('chdir', None)
-        self.child_jobs[name]._sbatch.pop('J', None)
-        self.child_jobs[name]._sbatch.pop('job_name', None)
-        self.child_jobs[name]._sbatch.pop('o', None)
-        self.child_jobs[name]._sbatch.pop('output', None)
         setattr(self, name, self.child_jobs[name])
 
         if not add_frag_to_mol:
@@ -568,7 +562,7 @@ class ADFFragmentJob(ADFJob):
                 self.settings.input.adf.fragments[frag_name + '_STOFIT'] = j(elstat_jobs['frag_' + frag_name + '_STOFIT'].workdir, 'adf.rkf')
             self.settings.input.adf.STOFIT = ''
             self.settings.input.adf.PRINT = 'FmatSFO Elstat'
-
+            [self._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
             log.flow(log.Emojis.good + ' Submitting complex with STOFIT', ['split'])
             super().run()
             log.flow(f'SlurmID: {self.slurm_job_id}', ['straight', 'end'])
@@ -606,7 +600,7 @@ class ADFFragmentJob(ADFJob):
                 self.spin_polarization(total_spin_polarization)
 
                 log.flow(log.Emojis.good + f' Submitting complex with 0 electrons in fragment {frag}', ['split'])
-
+                [self._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                 super().run()
                 log.flow(f'SlurmID: {self.slurm_job_id}', ['straight', 'end'])
                 log.flow()

--- a/src/tcutility/molecule.py
+++ b/src/tcutility/molecule.py
@@ -107,6 +107,28 @@ def load(path) -> plams.Molecule:
 
     return mol
 
+def from_string(s: str) -> plams.Molecule:
+    mol = plams.Molecule()
+    for line in s.splitlines():
+        parts = [parse_str(part) for part in line.split()]
+        if len(parts) < 4:
+            continue
+
+        # check if first part is the symbol of the molecule
+        if not isinstance(parts[0], str) and len(parts[0]) > 2:
+            continue
+
+        # check if
+        if not all(isinstance(part, (float, int)) for part in parts[1:4]):
+            continue
+
+        atom = plams.Atom(symbol=parts[0], coords=parts[1:4])
+        mol.add_atom(atom)
+
+    return mol
+
+
+
 
 def guess_fragments(mol: plams.Molecule) -> Dict[str, plams.Molecule]:
     """

--- a/src/tcutility/pathfunc.py
+++ b/src/tcutility/pathfunc.py
@@ -192,4 +192,7 @@ def match(root: str, pattern: str, sort_by: str = None) -> Dict[str, dict]:
         # get the group data and add it to the return dictionary. We skip the first group because it is the full directory path
         ret[p] = results.Result(directory=p, **{substitutions[i]: match.group(i + 1) for i in range(len(substitutions))})
 
-    return ret
+    if not sort_by:
+        return ret
+
+    return results.Result(sorted(ret.items(), key=lambda d: d[1][sort_by]))

--- a/src/tcutility/pathfunc.py
+++ b/src/tcutility/pathfunc.py
@@ -101,7 +101,7 @@ def get_subdirectories(root: str, include_intermediates: bool = False) -> List[s
     return subdirs
 
 
-def match(root: str, pattern: str) -> Dict[str, dict]:
+def match(root: str, pattern: str, sort_by: str = None) -> Dict[str, dict]:
     """
     Find and return information about subdirectories of a root that match a given pattern.
 

--- a/src/tcutility/report/__init__.py
+++ b/src/tcutility/report/__init__.py
@@ -1,1 +1,1 @@
-from . import character  # noqa
+from . import character, figure_resizer  # noqa

--- a/src/tcutility/report/figure_resizer.py
+++ b/src/tcutility/report/figure_resizer.py
@@ -1,0 +1,135 @@
+'''
+This module is used for resizing pictures containing molecules.
+'''
+import numpy as np
+import cv2
+import matplotlib.pyplot as plt
+import os
+
+
+def _analyse_img(file, plot=False):
+    '''
+    Function used for analysing and getting useful information from an image.
+    This includes circle locations and sizes.
+    '''
+    # Read image
+    img = cv2.imread(file, cv2.IMREAD_UNCHANGED)
+    img = _remove_padding(img)
+    # Smooth it
+    img_copy = img.copy()
+
+    # Convert to greyscale
+    img_gray = cv2.medianBlur(img_copy, 3)
+    img_gray = cv2.cvtColor(img_gray, cv2.COLOR_BGRA2GRAY)
+
+    # Apply Hough transform to greyscale image
+    circles = cv2.HoughCircles(img_gray, cv2.HOUGH_GRADIENT, 1, 100,
+                               param1=60, param2=40, minRadius=0, maxRadius=200)
+    circles = np.uint16(np.around(circles))[0]
+    circles = circles[(-circles[:, 2]).argsort()]
+    x = np.arange(0, img.shape[1])
+    y = np.arange(0, img.shape[0])
+
+    # Draw the circles
+    colors = []
+    radii = []
+
+    if plot:
+        img_copy = cv2.cvtColor(img_copy, cv2.COLOR_BGR2RGB)
+        for i, circle in enumerate(circles):
+            # draw the outer circle
+            cv2.circle(img_copy,(circle[0],circle[1]),circle[2],(0,255,0),2)
+            # draw the center of the circle
+            cv2.circle(img_copy,(circle[0],circle[1]),2,(0,0,255),3)
+            cv2.putText(img_copy, str(i), (circle[0] - 40, circle[1] + 44), cv2.FONT_HERSHEY_SIMPLEX, 4, (0, 0, 0), 16, cv2.LINE_AA)
+            cv2.putText(img_copy, str(i), (circle[0] - 40, circle[1] + 44), cv2.FONT_HERSHEY_SIMPLEX, 4, (255, 255, 255), 8, cv2.LINE_AA)
+
+        plt.imshow(img_copy)
+        plt.draw()
+        plt.pause(0.001)
+    return circles, img
+
+
+def _remove_padding(img):
+    '''
+    Function used to remove padding from an image.
+    '''
+    gray = cv2.cvtColor(img, cv2.COLOR_BGRA2GRAY)
+    gray = 255*(gray < 240).astype(np.uint8) # To invert the text to white
+    coords = cv2.findNonZero(gray) # Find all non-zero points (text)
+    x, y, w, h = cv2.boundingRect(coords) # Find minimum spanning bounding box
+    rect = img[y:y+h, x:x+w] # Crop the image - note we do this on the original image
+    return rect
+
+
+def resize(d, circle_numbers: dict = None, padding: str or int = 0):
+    '''
+    The main function for this module. 
+    Takes a directory `d` and selected circles and resizes and moves images in order to produce new aligned images.
+
+    Args:
+        d: the directory to take images from.
+        circle_numbers: a dictionary containing the image names as keys and circle indices as the values. 
+            The new images will be aligned based on these selected circles.
+        padding: the amount of padding to add to the new images.
+            If given an integer, it adds `padding` number of pixels.
+            Alternatively a string consisting of a number and a `%` sign can be given to add relative padding. 
+            E.g. `padding='10%'` will add a 10% padding to the images.
+    '''
+    circles = {}
+    imgs = {}
+    for file in os.listdir(d):
+        if file == '.DS_Store':
+            continue
+        if file not in circle_numbers:
+            continue
+        circles_, img_ = _analyse_img(os.path.join(d, file))
+        circles[file] = circles_[circle_numbers[file]]
+        imgs[file] = img_
+
+    # get the atom sizes, which is simply the radius of the circle we selected
+    atom_sizes = {file: circle[2] for file, circle in circles.items()}
+    # calculate ratios for resizing the images
+    ratios = {file: max(atom_sizes.values())/size for file, size in atom_sizes.items()}
+    # resize old images to make new ones
+    imgs = {file: cv2.resize(img, [int(round(img.shape[1] * ratios[file])), int(round(img.shape[0] * ratios[file]))]) for file, img in imgs.items()}
+    # also resize circles to match the new ratio
+    circles = {file: circle * ratios[file] for file, circle in circles.items()}
+
+    # now find out where to place the circles
+    circle_x = [circle[0] for circle in circles.values()]
+    circle_y = [circle[1] for file, circle in circles.items()]
+
+    pad_left = {file: int((max(circle_x) - circle[0])) for file, circle in circles.items()}
+    pad_top = {file: int((max(circle_y) - circle[1])) for file, circle in circles.items()}
+
+    pad = {file: [(pad_top[file], 0), (pad_left[file], 0), (0, 0)] for file in imgs}
+    imgs = {file: np.pad(img, pad[file], constant_values=0) for file, img in imgs.items()}
+
+    imsize_x = [img.shape[1] for img in imgs.values()]
+    imsize_y = [img.shape[0] for img in imgs.values()]
+
+    pad_right = {file: int(max(imsize_x) - img.shape[1]) for file, img in imgs.items()}
+    pad_bottom = {file: int(max(imsize_y) - img.shape[0]) for file, img in imgs.items()}
+
+    pad = {file: [(0, pad_bottom[file]), (0, pad_right[file]), (0, 0)] for file in imgs}
+    imgs = {file: np.pad(img, pad[file], constant_values=0) for file, img in imgs.items()}
+
+    # add final padding
+    if isinstance(padding, str) and padding.endswith('%'):
+        padding = float(padding.removesuffix('%'))/100
+        padding = int(padding * list(imgs.values())[0].shape[1]), int(padding * list(imgs.values())[0].shape[0])
+    else:
+        padding = int(padding), int(padding)
+
+    pad = {file: [(padding[0], padding[0]), (padding[1], padding[1]), (0, 0)] for file in imgs}
+    imgs = {file: np.pad(img, pad[file], constant_values=0) for file, img in imgs.items()}
+
+    os.makedirs(d + '_fixed', exist_ok=True)
+    for file, img in imgs.items():
+        cv2.imwrite(os.path.join(d + '_fixed', file), img)
+
+    cv2.imwrite(os.path.join(d + '_fixed', 'empty.png'), np.zeros_like(img) + np.array([255, 255, 255, 0]))
+    ret = {file: os.path.join(d + '_fixed', file) for file in imgs}
+    ret['empty.png'] = os.path.join(d + '_fixed', 'empty.png')
+    return ret

--- a/src/tcutility/results/adf.py
+++ b/src/tcutility/results/adf.py
@@ -186,6 +186,9 @@ def get_properties(info: Result) -> Result:
             - **s2** - expectation value of the :math:`S^2` operator.
             - **s2_expected** - ideal expectation value of the :math:`S^2` operator. For restricted calculations this should always equal ``s2``.
             - **spin_contamination** - the amount of spin-contamination observed in this calculation. It is equal to (s2 - s2_expected) / (s2_expected). Ideally this value should be below 0.1.
+            - **dipole_vector** - the dipole moment vector.
+            - **dipole_moment** - the magnitude of the dipole moment vector.
+            - **quadrupole_moment** - the quadrupole moment vector.
     """
 
     assert info.engine == "adf", f"This function reads ADF data, not {info.engine} data"
@@ -277,6 +280,10 @@ def get_properties(info: Result) -> Result:
         ret.spin_contamination = (ret.s2 - ret.s2_expected) / (ret.s2_expected)
     else:
         ret.spin_contamination = 0
+
+    ret.dipole_vector = reader_adf.read("Properties", "Dipole")
+    ret.dipole_moment = np.linalg.norm(ret.dipole_vector)
+    ret.quadrupole_moment = reader_adf.read("Properties", "Quadrupole")
 
     return ret
 

--- a/src/tcutility/results/adf.py
+++ b/src/tcutility/results/adf.py
@@ -189,6 +189,7 @@ def get_properties(info: Result) -> Result:
             - **dipole_vector** - the dipole moment vector.
             - **dipole_moment** - the magnitude of the dipole moment vector.
             - **quadrupole_moment** - the quadrupole moment vector.
+            - **dens_at_atom** - the electron density at each atom.
     """
 
     assert info.engine == "adf", f"This function reads ADF data, not {info.engine} data"
@@ -284,6 +285,8 @@ def get_properties(info: Result) -> Result:
     ret.dipole_vector = reader_adf.read("Properties", "Dipole")
     ret.dipole_moment = np.linalg.norm(ret.dipole_vector)
     ret.quadrupole_moment = reader_adf.read("Properties", "Quadrupole")
+    ret.dens_at_atom = ensure_list(reader_adf.read("Properties", "Electron Density at nuclear_internal"))
+
 
     return ret
 

--- a/src/tcutility/results/adf.py
+++ b/src/tcutility/results/adf.py
@@ -122,14 +122,13 @@ def _read_vdd_charges(kf_reader: KFReader) -> arrays.Array1D[np.float64]:
 def _read_vdd_charges_initial(kf_reader: KFReader) -> arrays.Array1D[np.float64]:
     """Returns the initial VDD charges from the KFReader object."""
     vdd_ini: List[float] = ensure_list(kf_reader.read("Properties", "AtomCharge_initial Voronoi"))  # type: ignore since plams does not include typing for KFReader. List[float] is returned
-    return np.array(vdd_scf)
+    return np.array(vdd_ini)
 
 
 def _read_vdd_charges_SCF(kf_reader: KFReader) -> arrays.Array1D[np.float64]:
     """Returns the SCF VDD charges from the KFReader object."""
     vdd_scf: List[float] = ensure_list(kf_reader.read("Properties", "AtomCharge_SCF Voronoi"))  # type: ignore since plams does not include typing for KFReader. List[float] is returned
     return np.array(vdd_scf)
-
 
 
 def _get_vdd_charges_per_irrep(results_type: KFReader) -> Dict[str, arrays.Array1D[np.float64]]:

--- a/src/tcutility/results/adf.py
+++ b/src/tcutility/results/adf.py
@@ -119,6 +119,19 @@ def _read_vdd_charges(kf_reader: KFReader) -> arrays.Array1D[np.float64]:
     return np.array([float((scf - ini)) for scf, ini in zip(vdd_scf, vdd_ini)])
 
 
+def _read_vdd_charges_initial(kf_reader: KFReader) -> arrays.Array1D[np.float64]:
+    """Returns the initial VDD charges from the KFReader object."""
+    vdd_ini: List[float] = ensure_list(kf_reader.read("Properties", "AtomCharge_initial Voronoi"))  # type: ignore since plams does not include typing for KFReader. List[float] is returned
+    return np.array(vdd_scf)
+
+
+def _read_vdd_charges_SCF(kf_reader: KFReader) -> arrays.Array1D[np.float64]:
+    """Returns the SCF VDD charges from the KFReader object."""
+    vdd_scf: List[float] = ensure_list(kf_reader.read("Properties", "AtomCharge_SCF Voronoi"))  # type: ignore since plams does not include typing for KFReader. List[float] is returned
+    return np.array(vdd_scf)
+
+
+
 def _get_vdd_charges_per_irrep(results_type: KFReader) -> Dict[str, arrays.Array1D[np.float64]]:
     """Extracts the Voronoi Deformation Density charges from the fragment calculation sorted per irrep."""
     symlabels = str(results_type.read("Symmetry", "symlab")).split()  # split on whitespace
@@ -261,6 +274,8 @@ def get_properties(info: Result) -> Result:
     # read the Voronoi Deformation Charges Deformation (VDD) before and after SCF convergence (being "inital" and "SCF")
     try:
         ret.vdd.charges = _read_vdd_charges(reader_adf)
+        ret.vdd.charges_initial = _read_vdd_charges_initial(reader_adf)
+        ret.vdd.charges_SCF = _read_vdd_charges_SCF(reader_adf)
         ret.vdd.update(_get_vdd_charges_per_irrep(reader_adf))
     except KeyError:
         pass
@@ -286,7 +301,6 @@ def get_properties(info: Result) -> Result:
     ret.dipole_moment = np.linalg.norm(ret.dipole_vector)
     ret.quadrupole_moment = reader_adf.read("Properties", "Quadrupole")
     ret.dens_at_atom = ensure_list(reader_adf.read("Properties", "Electron Density at Nuclei"))
-
 
     return ret
 

--- a/src/tcutility/results/adf.py
+++ b/src/tcutility/results/adf.py
@@ -285,7 +285,7 @@ def get_properties(info: Result) -> Result:
     ret.dipole_vector = reader_adf.read("Properties", "Dipole")
     ret.dipole_moment = np.linalg.norm(ret.dipole_vector)
     ret.quadrupole_moment = reader_adf.read("Properties", "Quadrupole")
-    ret.dens_at_atom = ensure_list(reader_adf.read("Properties", "Electron Density at nuclear_internal"))
+    ret.dens_at_atom = ensure_list(reader_adf.read("Properties", "Electron Density at Nuclei"))
 
 
     return ret

--- a/src/tcutility/results/ams.py
+++ b/src/tcutility/results/ams.py
@@ -290,7 +290,7 @@ def _make_molecule(kf_variable: str, reader_ams: plams.KFReader, natoms: int, at
     coords = np.array(reader_ams.read(kf_variable, "Coords")).reshape(natoms, 3) * constants.BOHR2ANG
     for atnum, coord in zip(atnums, coords):
         ret_mol.add_atom(plams.Atom(atnum=atnum, coords=coord))
-    if ("Molecule", "fromAtoms") in reader_ams and ("Molecule", "toAtoms") in reader_ams and ("Molecule", "bondOrders"):
+    if ("Molecule", "fromAtoms") in reader_ams and ("Molecule", "toAtoms") in reader_ams and ("Molecule", "bondOrders") in reader_ams:
         at_from = ensure_list(reader_ams.read("InputMolecule", "fromAtoms"))
         at_to = ensure_list(reader_ams.read("InputMolecule", "toAtoms"))
         bos = ensure_list(reader_ams.read("InputMolecule", "bondOrders"))


### PR DESCRIPTION
There were some issues related to the recent implementation of the electrostatic potential decomposition analysis with `ADFFragmentJob`. This PR aims to fix those issues.

- Fixed an issue related to sbatch settings not properly being set for child jobs
- Fixed an issue where we could not access the `job` module without explicitly importing it
- Fixed a problem where the `Elstat` print option was overwriting the user-set print options