### PR TITLE
Not printing timing table if there were no calls to registered callables

### DIFF
--- a/src/tcutility/timer.py
+++ b/src/tcutility/timer.py
@@ -51,6 +51,9 @@ def print_timings():
     if not enabled:
         return
 
+    if sum(time['calls'] for time in times.values()) == 0:
+        return
+
     names = list(times.keys())
     names = sorted(names)
     names_splits = [name.split('.') for name in names]


### PR DESCRIPTION
Whenever something was registered to the timing module we printed a table at the end of the runtime, however this is not necessary if there were no calls made to the registered callables.