### PR TITLE
`tc resize` now uses a filedialog instead of required folder option

### DIFF
--- a/src/tcutility/cli_scripts/resize_figures.py
+++ b/src/tcutility/cli_scripts/resize_figures.py
@@ -2,6 +2,11 @@
 import argparse
 from tcutility import report
 import os
+import tkinter as tk
+from tkinter import filedialog
+
+root = tk.Tk()
+root.withdraw()
 
 
 def create_subparser(parent_parser: argparse.ArgumentParser):
@@ -26,14 +31,17 @@ Add a %%-sign to use relative padding. E.g. -p 10%% will add a padding of 10%%."
 
 def main(args: argparse.Namespace):
     circle_numbers = {}
-    for img_path in os.listdir(args.folder[0]):
-        report.figure_resizer.get_data(os.path.join(args.folder[0], img_path), plot=True)
+    if args.folder is not None:
+        img_paths = [os.path.join(args.folder, img_path) for img_path in os.listdir(args.folder)]
+    else:
+        img_paths = filedialog.askopenfilenames()
+
+    for img_path in img_paths:
+        report.figure_resizer._analyse_img(img_path, plot=True)
         circle = input(f'Select circle for {img_path}, leave empty to skip: ')
         if circle == '':
             continue
 
         circle_numbers[img_path] = int(circle)
 
-    report.figure_resizer.resize(args.folder[0], circle_numbers, padding=args.padding)
-
-    # print(args.folder)
+    report.figure_resizer.resize(img_paths, circle_numbers, padding=args.padding)

--- a/src/tcutility/cli_scripts/resize_figures.py
+++ b/src/tcutility/cli_scripts/resize_figures.py
@@ -13,10 +13,10 @@ Entering the desired number into the CLI will select it for resizing. If you do 
 New images will be written to the folder postpended with _fixed.
     """
     subparser = parent_parser.add_parser('resize', help=desc, description=desc, formatter_class=argparse.RawTextHelpFormatter)
-    subparser.add_argument("folder",
+    subparser.add_argument("-f", "--folder",
                            type=str,
-                           nargs=1,
-                           help="A folder containing images containing molecules which will be resized.")
+                           help="A folder containing images containing molecules which will be resized.",
+                           default=None)
     subparser.add_argument("-p", "--padding",
                            help="""The amount of padding to add to the resized figures.
 If given an integer we use pixel padding. E.g. -p 50 will add a padding of 50 pixels.

--- a/src/tcutility/report/figure_resizer.py
+++ b/src/tcutility/report/figure_resizer.py
@@ -62,7 +62,7 @@ def _remove_padding(img):
     return rect
 
 
-def resize(d, circle_numbers: dict = None, padding: str or int = 0):
+def resize(files, circle_numbers: dict = None, padding: str or int = 0):
     '''
     The main function for this module. 
     Takes a directory `d` and selected circles and resizes and moves images in order to produce new aligned images.
@@ -78,12 +78,12 @@ def resize(d, circle_numbers: dict = None, padding: str or int = 0):
     '''
     circles = {}
     imgs = {}
-    for file in os.listdir(d):
+    for file in files:
         if file == '.DS_Store':
             continue
         if file not in circle_numbers:
             continue
-        circles_, img_ = _analyse_img(os.path.join(d, file))
+        circles_, img_ = _analyse_img(file)
         circles[file] = circles_[circle_numbers[file]]
         imgs[file] = img_
 
@@ -125,11 +125,12 @@ def resize(d, circle_numbers: dict = None, padding: str or int = 0):
     pad = {file: [(padding[0], padding[0]), (padding[1], padding[1]), (0, 0)] for file in imgs}
     imgs = {file: np.pad(img, pad[file], constant_values=0) for file, img in imgs.items()}
 
-    os.makedirs(d + '_fixed', exist_ok=True)
+    ret = {}
     for file, img in imgs.items():
-        cv2.imwrite(os.path.join(d + '_fixed', file), img)
+        new_file = file.split('.')[0] + '_resized.' + file.split('.')[1]
+        cv2.imwrite(new_file, img)
+        ret[file] = new_file
 
-    cv2.imwrite(os.path.join(d + '_fixed', 'empty.png'), np.zeros_like(img) + np.array([255, 255, 255, 0]))
-    ret = {file: os.path.join(d + '_fixed', file) for file in imgs}
-    ret['empty.png'] = os.path.join(d + '_fixed', 'empty.png')
+    cv2.imwrite('.empty_resized.png', np.zeros_like(img) + np.array([255, 255, 255, 0]))
+    ret['empty.png'] = '.empty_resized.png'
     return ret


### PR DESCRIPTION
Previously, the `tc resize` program required the user to provide a directory with images. Now if a directory is not given it will open a filedialog by default where you can select images to process.