### PR TITLE
`tcutility.data.atom.color` calls can be now be given as hex strings instead of RGB only

### DIFF
--- a/src/tcutility/data/atom.py
+++ b/src/tcutility/data/atom.py
@@ -63,16 +63,22 @@ def radius(element):
     return _radii.get(num)
 
 
-def color(element):
+def color(element, mode: str = 'rgb'):
     '''
     Args:
         element: the symbol, name or atom number of the element. See :func:`parse_element`.
+        mode: the type of color to return. Can be `rgb` or `hex`.
 
     Return:
-        The standard CPK colors of the elements, up to element 109.
+        The standard CPK colors of the elements, up to element 109. 
+        If the mode is `rgb` returns a tuple of RGB values between `0` and `255`.
     '''
     num = parse_element(element)
-    return _colors[num]
+    c = _colors[num]
+    if mode == 'rgb':
+        return c
+    if mode == 'hex':
+        return '#%02x%02x%02x' % tuple(c)
 
 
 def atom_number(element):


### PR DESCRIPTION
Previously atomic colors were returned as RGB values only. Now we can also get them as hex strings.