### PR TITLE
Fixed an issue where unrestrictedness was not propagated to childjobs in `ADFFragmentJob` calculations

### DIFF
--- a/examples/job/uvvis.py
+++ b/examples/job/uvvis.py
@@ -3,12 +3,25 @@ from tcutility.job import ADFJob, ADFFragmentJob
 
 # uv/vis calculations can be run on singlepoint jobs
 with ADFJob() as job:
-	job.molecule('../NH3BH3.xyz')
+	job.rundir = 'uvvis'
+	job.name = 'restricted'
+	job.molecule('NH3BH3.xyz')
 	job.excitations()
 
 # and also fragment jobs
 # in this case the SFOs are simply built up of the fragment densities
 with ADFFragmentJob() as job:
-	job.molecule('../NH3BH3.xyz')
+	job.rundir = 'uvvis'
+	job.name = 'fragment'
+	job.molecule('NH3BH3.xyz')
 	job.excitations()
+
+
+with ADFJob() as job:
+	job.rundir = 'uvvis'
+	job.name = 'unrestricted'
+	job.molecule('NH3BH3.xyz')
+	job.excitations()
+	job.unrestricted(True)
+
 

--- a/examples/job/uvvis.py
+++ b/examples/job/uvvis.py
@@ -17,11 +17,9 @@ with ADFFragmentJob() as job:
 	job.excitations()
 
 
-with ADFJob() as job:
+with ADFFragmentJob() as job:
 	job.rundir = 'uvvis'
-	job.name = 'unrestricted'
+	job.name = 'fragment_unrestricted'
 	job.molecule('NH3BH3.xyz')
 	job.excitations()
 	job.unrestricted(True)
-
-

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -519,7 +519,7 @@ class ADFFragmentJob(ADFJob):
         log.flow(f"ADFFragmentJob [{mol_str}]", ["start"])
         # obtain some system wide properties of the molecules
         charge = sum([child.settings.input.ams.System.charge or 0 for child in self.child_jobs.values()])
-        unrestricted = any([(child.settings.input.adf.Unrestricted or "no").lower() == "yes" for child in self.child_jobs.values()])
+        unrestricted = any([(child.settings.input.adf.Unrestricted or "no").lower() == "yes" for child in self.child_jobs.values()]) or (self.settings.input.adf.Unrestricted or "no").lower() == "yes"
         spinpol = sum([child.settings.input.adf.SpinPolarization or 0 for child in self.child_jobs.values()])
         log.flow(f"Level:             {self._functional}/{self._basis_set}")
         log.flow(f"Solvent:           {self._solvent}")


### PR DESCRIPTION
Previously, running the following script:
```python
with ADFFragmentJob() as job:
	job.molecule(...)
	job.unrestricted(True)
```
Would result in an error mentioning that the `UnrestrictedFragments` keyword was not set in the input file of the complex. This PR will fix this issue.

I also changed the uvvis example as a little bonus.