### PR TITLE
Added calculation of sum of angles to `geometry.parameter`

### DIFF
--- a/src/tcutility/cli_scripts/geo.py
+++ b/src/tcutility/cli_scripts/geo.py
@@ -21,8 +21,9 @@ class GeometricParameter(StrEnum):
 geometric_character_to_info_mapping: Dict[GeometricParameter, Tuple[str, str, int]] = {
     GeometricParameter.COORDINATE: ("Coordinate", "Å", 6),
     GeometricParameter.DISTANCE: ("Distance", " Å", 3),
-    GeometricParameter.COORDINATE: ("Angle", "°", 2),
+    GeometricParameter.ANGLE: ("Angle", "°", 2),
     GeometricParameter.DIHEDRAL: ("Dihedral", "°", 2),
+    GeometricParameter.PYRAMIDAL: ("Pyramidal", "°", 2),
     GeometricParameter.SUMOFANGLES: ("SumOfAngles", "°", 2),
 }
 

--- a/src/tcutility/cli_scripts/geo.py
+++ b/src/tcutility/cli_scripts/geo.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Tuple
 
 import click
 from strenum import StrEnum
-from tcutility import geometry, molecule
+from tcutility import geometry, molecule, results
 
 
 class GeometricParameter(StrEnum):
@@ -15,6 +15,7 @@ class GeometricParameter(StrEnum):
     ANGLE = "Angle"
     DIHEDRAL = "Dihedral"
     PYRAMIDAL = "Pyramidal"
+    SUMOFANGLES = 'SumOfAngles'
 
 
 geometric_character_to_info_mapping: Dict[GeometricParameter, Tuple[str, str, int]] = {
@@ -22,32 +23,44 @@ geometric_character_to_info_mapping: Dict[GeometricParameter, Tuple[str, str, in
     GeometricParameter.DISTANCE: ("Distance", " Å", 3),
     GeometricParameter.COORDINATE: ("Angle", "°", 2),
     GeometricParameter.DIHEDRAL: ("Dihedral", "°", 2),
-    GeometricParameter.PYRAMIDAL: ("Pyramidal", "°", 2),
+    GeometricParameter.SUMOFANGLES: ("SumOfAngles", "°", 2),
 }
 
 
 @click.command()
-@click.argument("xyzfile", type=click.Path(exists=True))
+@click.argument("path", type=click.Path(exists=True))
 @click.argument("atom_indices", type=str, nargs=-1)
-@click.option("-p", "--pyramidal", is_flag=True, default=False, help="Instead of calculating dihedral angles, calculate pyramidalisation angle.")
-def calculate_geometry_parameter(xyzfile: str, atom_indices: List[str], pyramidal: bool) -> None:
+@click.option("-p", "--pyramidal", is_flag=True, default=False, help="Instead of calculating a dihedral angle, calculate pyramidalisation angle.")
+@click.option("-s", "--soa", is_flag=True, default=False, help="Instead of calculating a dihedral angle, calculate sum-of-angles angle.")
+def calculate_geometry_parameter(path: str, atom_indices: List[str], pyramidal: bool, soa: bool) -> None:
     """
-    Calculate geometrical parameters for atoms at the provided indices.
-
+    \b
+    Calculate geometrical parameters for atoms at the provided ATOM_INDICES (NB: counting starts at 1).
+    PATH should be an XYZ-file or a calculation directory.
+    
+    \b
     For 1 index this program returns the cartesian coordinate for this atom.
     For 2 indices return bond length between atoms.
     For 3 indices return bond angle, with the second index being the central atom.
-    For 4 indices return dihedral angle by calculating the angle between normal vectors described by atoms at indices 1-2-3 and indices 2-3-4.
-    If the -p/--pyramidal flag is turned on it calculates 360° - ang1 - ang2 - ang3, where ang1, ang2 and ang3 are the angles described by indices 2-1-3, 3-1-4 and 4-1-2 respectively.
+    For 4 indices return dihedral angle by calculating the angle between normal vectors
+        described by atoms at indices 1-2-3 and indices 2-3-4.
+    \b
+    If the -p/--pyramidal flag is turned on it calculates 360° - ang1 - ang2 - ang3, 
+        where ang1, ang2 and ang3 are the angles described by indices 2-1-3, 3-1-4 
+        and 4-1-2 respectively.
+    If the -s/--soa flag is turned on it calculates ang1 + ang2 + ang3.
     """
-    mol = molecule.load(xyzfile)
+    try:
+        mol = molecule.load(path)
+    except IsADirectoryError:
+        mol = results.read(path).molecule.output
     indices = [int(i) - 1 for i in atom_indices]
 
     assert 1 <= len(indices) <= 4, f"Number of indices must be 1, 2, 3 or 4, not {len(indices)}"
 
     atoms = "-".join([f"{mol[i+1].symbol}{i+1}" for i in indices])
 
-    param_value = geometry.parameter(mol, *indices, pyramidal=pyramidal)
+    param_value = geometry.parameter(mol, *indices, pyramidal=pyramidal, sum_of_angles=soa)
 
     if len(indices) == 1:
         param_value = "  ".join([f"{x: .6f}" for x in mol[indices[0] + 1].coords])
@@ -56,10 +69,13 @@ def calculate_geometry_parameter(xyzfile: str, atom_indices: List[str], pyramida
         param_type = GeometricParameter.DISTANCE
     elif len(indices) == 3:
         param_type = GeometricParameter.ANGLE
-    elif len(indices) == 4 and not pyramidal:
-        param_type = GeometricParameter.DIHEDRAL
-    elif len(indices) == 4 and pyramidal:
-        param_type = GeometricParameter.PYRAMIDAL
+    elif len(indices) == 4:
+        if pyramidal:
+            param_type = GeometricParameter.PYRAMIDAL
+        elif soa:
+            param_type = GeometricParameter.SUMOFANGLES
+        else:
+            param_type = GeometricParameter.DIHEDRAL
     else:
         raise ValueError("Invalid number of indices")
 

--- a/src/tcutility/geometry.py
+++ b/src/tcutility/geometry.py
@@ -609,9 +609,20 @@ def random_points_on_spheroid(coordinates: np.ndarray, Nsamples: int = 1, margin
     return transform(p)
 
 
-def parameter(coordinates, *indices, pyramidal=False):
+def parameter(coordinates: np.typing.ArrayLike, *indices: Sequence[int], pyramidal: bool = False, sum_of_angles: bool = False):
     '''
-    Return geometry information about a set of coordinates given indices.
+    Return geometry information about a set of coordinates given 1 to 4 indices.
+    If 1 index is given we return the coordinate at that index.
+    If 2 indices are given we return the distance between the coordinates at the indices.
+    If 3 indices are given we return the angle between the vector from index 1 to 2 and the vector from index 2 to 3.
+    If 4 indices are given we return the dihedral angle or the pyramidalization angle (if `pyramidal` is set to `True`) or the sum-of-angles (if `sum_of_angles` is set to `True`).
+    
+    Args:
+        coordinates: set of coordinates to calculate parameters for.
+        indices: 1 to 4 integers specifying the indices to use in the coordinates set.
+        pyramidal: if 4 indices are given return the pyramidalization angle in degrees.
+        sum_of_angles: if 4 indices are given return the sum of the angles between the first index and the rest in degrees.
+
     '''
     assert 1 <= len(indices) <= 4, "Number of indices must be between 1, 2, 3 or 4"
 

--- a/src/tcutility/geometry.py
+++ b/src/tcutility/geometry.py
@@ -643,7 +643,22 @@ def parameter(coordinates: np.typing.ArrayLike, *indices: Sequence[int], pyramid
 
         return np.arccos(a @ b) / np.pi * 180
 
-    if len(indices) == 4 and not pyramidal:
+    if len(indices) == 4:
+        if pyramidal:
+            ang1 = parameter(coordinates, indices[1], indices[0], indices[2])
+            ang2 = parameter(coordinates, indices[2], indices[0], indices[3])
+            ang3 = parameter(coordinates, indices[3], indices[0], indices[1])
+
+            return 360 - ang1 - ang2 - ang3
+
+        if sum_of_angles:
+            ang1 = parameter(coordinates, indices[1], indices[0], indices[2])
+            ang2 = parameter(coordinates, indices[2], indices[0], indices[3])
+            ang3 = parameter(coordinates, indices[3], indices[0], indices[1])
+
+            return ang1 + ang2 + ang3
+
+        # if we dont want pyramidal or sum of angles return the dihedral angle
         a = selected_coords[0] - selected_coords[1]
         b = selected_coords[2] - selected_coords[1]
 
@@ -656,11 +671,3 @@ def parameter(coordinates: np.typing.ArrayLike, *indices: Sequence[int], pyramid
         n2 = n2 / np.linalg.norm(n2)
 
         return np.arccos(n1 @ n2) / np.pi * 180
-
-
-    if len(indices) == 4 and pyramidal:
-        ang1 = parameter(coordinates, indices[1], indices[0], indices[2])
-        ang2 = parameter(coordinates, indices[2], indices[0], indices[3])
-        ang3 = parameter(coordinates, indices[3], indices[0], indices[1])
-
-        return 360 - ang1 - ang2 - ang3


### PR DESCRIPTION
* We can now calculate the sum of angles with the `geometry.parameter` function.
* Sum-of-angle calculations have also been added to the `tc geo` CLI program
* The `tc geo` CLI can now be provided a calculation directory instead of only a XYZ-file.
* If 0 indices are given to `tc geo` we print the whole molecule.
* General improvements to the documentation of `tc geo`