### PR TITLE
Made job status checking more efficient

### DIFF
--- a/src/tcutility/__init__.py
+++ b/src/tcutility/__init__.py
@@ -14,4 +14,4 @@ def ensure_2d(x, transposed=False):
     return x
 
 
-from tcutility import job, constants, formula, geometry, log, molecule, results, slurm, data, analysis, report, pathfunc  # noqa: F401, E402
+from tcutility import job, constants, formula, geometry, log, molecule, results, slurm, data, analysis, report, pathfunc, timer  # noqa: F401, E402

--- a/src/tcutility/job/generic.py
+++ b/src/tcutility/job/generic.py
@@ -44,7 +44,6 @@ class Job:
         wait_for_finish: whether to wait for this job to finish running before continuing your runscript.
         delete_on_finish: whether to remove the workdir for this job after it is finished running.
     """
-
     def __init__(
         self, *base_jobs: List["Job"], test_mode: bool = None, overwrite: bool = None, wait_for_finish: bool = None, delete_on_finish: bool = None, delete_on_fail: bool = None, use_slurm: bool = True
     ):
@@ -96,7 +95,7 @@ class Job:
             yet for :class:`CRESTJob <tcutility.job.crest.CRESTJob>` and :class:`QCGJob <tcutility.job.crest.QCGJob>`. For the latter objects the job will always be rerun.
             This will be fixed in a later version of TCutility.
         """
-        res = results.read(self.workdir)
+        res = results.quick_status(self.workdir)
         return not res.status.fatal
 
     def in_queue(self):
@@ -104,7 +103,7 @@ class Job:
         Check whether the job is currently managed by slurm.
         We check this by loading the calculation and checking if the job status is 'RUNNING', 'COMPLETING', 'CONFIGURING' or 'PENDING'.
         """
-        res = results.read(self.workdir)
+        res = results.quick_status(self.workdir)
         return res.status.name in ["RUNNING", "COMPLETING", "CONFIGURING", "PENDING"]
 
     def __repr__(self):

--- a/src/tcutility/results/__init__.py
+++ b/src/tcutility/results/__init__.py
@@ -142,14 +142,22 @@ def quick_status(calc_dir: Union[str, pl.Path]) -> Result:
             - **code (str)** – calculation status written as one or two characters, one of ("S", "R", "U", "W" "F")
                 If the job is being managed by slurm it can also take values of ("CG", "CF", "PD").
     """
+    status = Result()
+    status.name = 'UNKNOWN'
+    status.reasons = []
+    status.fatal = True
+    status.code = 'U'
     for engine in [ams, orca, crest, xtb]:
-        status = engine.get_calculation_status(calc_dir)
-        if status != 'UNKNOWN':
-            return status
+        try:
+            status = engine.get_calculation_status(calc_dir)
+            if status.name != 'UNKNOWN':
+                return status
+        except:
+            pass
 
     # otherwise we check if the job is being managed by slurm
     if not slurm.workdir_info(calc_dir):
-        return ret
+        return status
 
     # get the statuscode from the workdir
     state = slurm.workdir_info(calc_dir).statuscode

--- a/src/tcutility/results/__init__.py
+++ b/src/tcutility/results/__init__.py
@@ -168,7 +168,9 @@ def quick_status(calc_dir: Union[str, pl.Path]) -> Result:
         'R': 'RUNNING'
     }.get(state, 'UNKNOWN')
 
-    ret.fatal = False
-    ret.name = state_name
-    ret.code = state
-    ret.reasons = []
+    status.fatal = False
+    status.name = state_name
+    status.code = state
+    status.reasons = []
+
+    return status

--- a/src/tcutility/results/__init__.py
+++ b/src/tcutility/results/__init__.py
@@ -125,6 +125,42 @@ def read(calc_dir: Union[str, pl.Path]) -> Result:
     return ret
 
 
-if __name__ == "__main__":
-    res = read("/Users/yumanhordijk/Library/CloudStorage/OneDrive-VrijeUniversiteitAmsterdam/RadicalAdditionBenchmark/data/abinitio/P_C2H2_NH2/OPT_pVTZ")
-    print(res.molecule)
+def quick_status(calc_dir: Union[str, pl.Path]) -> Result:
+    """
+    Quickly check the status of a calculation.
+
+    Args:
+        calc_dir: the directory of the calculation to check.
+    
+    Returns:
+        :Dictionary containing information about the calculation status:
+
+            - **fatal (bool)** – `True` if calculation cannot be read correctly, `False` otherwise
+            - **reasons (list[str])** – list of reasons to explain the status, they can be errors, warnings, etc.
+            - **name (str)** – calculation status written as a string, one of ("SUCCESS", "RUNNING", "UNKNOWN", "SUCCESS(W)", "FAILED").
+                If the job is being managed by slurm it can also take values of ("COMPLETING", "CONFIGURING", "PENDING").
+            - **code (str)** – calculation status written as one or two characters, one of ("S", "R", "U", "W" "F")
+                If the job is being managed by slurm it can also take values of ("CG", "CF", "PD").
+    """
+    for engine in [ams, orca, crest, xtb]:
+        status = engine.get_calculation_status(calc_dir)
+        if status != 'UNKNOWN':
+            return status
+
+    # otherwise we check if the job is being managed by slurm
+    if not slurm.workdir_info(calc_dir):
+        return ret
+
+    # get the statuscode from the workdir
+    state = slurm.workdir_info(calc_dir).statuscode
+    state_name = {
+        'CG': 'COMPLETING',
+        'CF': 'CONFIGURING',
+        'PD': 'PENDING',
+        'R': 'RUNNING'
+    }.get(state, 'UNKNOWN')
+
+    ret.fatal = False
+    ret.name = state_name
+    ret.code = state
+    ret.reasons = []

--- a/src/tcutility/results/__init__.py
+++ b/src/tcutility/results/__init__.py
@@ -152,7 +152,7 @@ def quick_status(calc_dir: Union[str, pl.Path]) -> Result:
             status = engine.get_calculation_status(calc_dir)
             if status.name != 'UNKNOWN':
                 return status
-        except:
+        except Exception:
             pass
 
     # otherwise we check if the job is being managed by slurm


### PR DESCRIPTION
I made the job status much more efficient by simply calling the `get_calculation_status` function of the engine results modules directly instead of first loading all data and then checking the status.

# ORCA job speedups
Testing the following code against my radical addition benchmark calculations:
```python
import tcutility


for folder, info in tcutility.pathfunc.match('data/abinitio', '{sp}_{sub}_{rad}/{job}/{subjob}').items():
    with tcutility.timer.timer('quick status'):
        qs = tcutility.results.quick_status(folder).name
    with tcutility.timer.timer('old status'):
        os = tcutility.results.read(folder).status.name

    assert qs == os
```
Results in a ~4.7x speedup
```
[2025/02/08 23:07:15] Function       Calls   Mean (s)   Time Spent (s)   Rel. Time
[2025/02/08 23:07:15] ─────────────────────────────────────────────────────────────
[2025/02/08 23:07:15] old status     1026    0.003      2.982             75%     
[2025/02/08 23:07:15] quick status   1026    0.001      0.635             16%     
[2025/02/08 23:07:15] ─────────────────────────────────────────────────────────────
[2025/02/08 23:07:15] TOTAL                             3.970            100%     
```

# AMS job speedups
Testing the same code against my recent calculations results in a ~3x speedup
```
[2025/02/08 23:13:50] Function       Calls   Mean (s)   Time Spent (s)   Rel. Time
[2025/02/08 23:13:50] ─────────────────────────────────────────────────────────────
[2025/02/08 23:13:50] old status     79      0.048      3.781             72%     
[2025/02/08 23:13:50] quick status   79      0.016      1.267             24%     
[2025/02/08 23:13:50] ─────────────────────────────────────────────────────────────
[2025/02/08 23:13:50] TOTAL                             5.262            100%     
```