### PR TITLE
Large speedups for the `tcutility.pathfunc` module

### DIFF
--- a/src/tcutility/pathfunc.py
+++ b/src/tcutility/pathfunc.py
@@ -34,81 +34,15 @@ def split_all(path: str) -> List[str]:
         path = a
 
 
-def get_subdirectories(root: str, include_intermediates: bool = False) -> List[str]:
+def get_subdirectories(root: str, include_intermediates: bool = False, max_depth: int = None, _current_depth: int = 0) -> List[str]:
     """
     Get all sub-directories of a root directory.
 
     Args:
         root: the root directory.
         include_intermediates: whether to include intermediate sub-directories instead of only the lowest levels.
-
-    Returns:
-        A list of sub-directories with ``root`` included in the paths.
-
-    Example:
-        Given a file-structure as follows:
-
-        .. code-block::
-
-            root
-            |- subdir_a
-            |  |- subsubdir_b
-            |  |- subsubdir_c
-            |- subdir_b
-            |- subdir_c
-
-        Then we get the following outputs.
-
-        .. tabs::
-
-            .. group-tab:: Including intermediates
-
-                .. code-block:: python
-
-                    >>> get_subdirectories('root', include_intermediates=True)
-                    ['root',
-                     'root/subdir_a',
-                     'root/subdir_a/subsubdir_b',
-                     'root/subdir_a/subsubdir_c',
-                     'root/subdir_b',
-                     'root/subdir_c']
-
-            .. group-tab:: Excluding intermediates
-
-                .. code-block:: python
-
-                    >>> get_subdirectories('root', include_intermediates=False)
-                    ['root/subdir_a/subsubdir_b',
-                     'root/subdir_a/subsubdir_c',
-                     'root/subdir_b',
-                     'root/subdir_c']
-    """
-    dirs = [root]
-    subdirs = set()
-
-    while len(dirs) > 0:
-        _dirs = []
-        for cdir in dirs:
-            csubdirs = [j(cdir, d) for d in os.listdir(cdir) if os.path.isdir(j(cdir, d))]
-            if len(csubdirs) == 0:
-                subdirs.add(cdir)
-            else:
-                if include_intermediates:
-                    subdirs.add(cdir)
-                _dirs.extend(csubdirs)
-
-        dirs = _dirs
-
-    return subdirs
-
-
-def get_subdirectories2(root: str, include_intermediates: bool = False, max_depth: int = None, _current_depth: int = 0) -> List[str]:
-    """
-    Get all sub-directories of a root directory.
-
-    Args:
-        root: the root directory.
-        include_intermediates: whether to include intermediate sub-directories instead of only the lowest levels.
+        max_depth: the maximum depth depth to look for subdirectories, 
+            e.g. setting it to `1` will return only the contents of the `root` path.
 
     Returns:
         A list of sub-directories with ``root`` included in the paths.
@@ -173,6 +107,12 @@ def get_subdirectories2(root: str, include_intermediates: bool = False, max_dept
 
     return contents
 
+
+def path_depth(path: str) -> int:
+    """
+    Calculate the depth of a given path.
+    """
+    return len(split_all(path))
 
 
 def match(root: str, pattern: str, sort_by: str = None) -> Dict[str, dict]:
@@ -254,7 +194,7 @@ def match(root: str, pattern: str, sort_by: str = None) -> Dict[str, dict]:
     # root dir can be any level deep. We should count how many directories are in root
     root_length = len(split_all(root))
     # get all subdirectories first, we can loop through them later
-    subdirs = get_subdirectories(root, include_intermediates=True)
+    subdirs = get_subdirectories(root, include_intermediates=True, max_depth=len(split_all(pattern)))
     # remove the root from the subdirectories. We cannot use str.removeprefix because it was added in python 3.9
     subdirs = [j(*split_all(subdir)[root_length:]) for subdir in subdirs if len(split_all(subdir)[root_length:]) > 0]
     for subdir in subdirs:
@@ -269,111 +209,6 @@ def match(root: str, pattern: str, sort_by: str = None) -> Dict[str, dict]:
 
     if not sort_by:
         return ret
-
-    return results.Result(sorted(ret.items(), key=lambda d: d[1][sort_by]))
-
-
-def path_depth(path: str) -> int:
-    """
-    Calculate the depth of a given path.
-    """
-    return len(split_all(path))
-
-
-def match2(root: str, pattern: str, sort_by: str = None, as_generator: bool = False) -> Dict[str, dict]:
-    """
-    Find and return information about subdirectories of a root that match a given pattern.
-
-    Args:
-        root: the root of the subdirectories to look in.
-        pattern: a string specifying the pattern the subdirectories should correspond to.
-            It should look similar to a format string, without the ``f`` in front of the string.
-            Inside curly braces you can put a variable name, which you can later extract from the results.
-            Anything inside curly braces will be matched to word characters (``[a-zA-Z0-9_-]``) including dashes and underscores.
-        sort_by: the key to sort the results by. If not given, the results will be returned in the order they were found.
-
-    Returns:
-        A |Result| object containing the matched directories as keys and information (also |Result| object) about those matches as the values. Each information dictionary contains the variables given in the pattern.
-        E.g. using a pattern such as ``{a}/{b}/{c}`` will populate the ``info.a``, ``info.b`` and ``info.c`` keys of the info |Result| object.
-
-    Example:
-        Given a file-structure as follows:
-
-        .. code-block::
-
-            root
-            |- NH3-BH3
-            |   |- BLYP_QZ4P
-            |   |  |- extra_dir
-            |   |  |- blablabla
-            |   |
-            |   |- BLYP_TZ2P
-            |   |  |- another_dir
-            |   |
-            |   |- M06-2X_TZ2P
-            |
-            |- SN2
-            |   |- BLYP_TZ2P
-            |   |- M06-2X_TZ2P
-            |   |  |- M06-2X_TZ2P
-
-        We can run the following scripts to match the subdirectories.
-
-        .. code-block:: python
-
-            from tcutility import log
-            # get the matches, we want to extract the system name (NH3-BH3 or SN2)
-            # and the functional and basis-set
-            # we don't want the subdirectories
-            matches = match('root', '{system}/{functional}_{basis_set}')
-
-            # print the matches as a table
-            rows = []
-            for d, info in matches.items():
-                rows.append([d, info.system, info.functional, info.basis_set])
-
-            log.table(rows, ['Directory', 'System', 'Functional', 'Basis-Set'])
-
-        which prints
-
-        .. code-block::
-
-            [2024/01/17 14:39:08] Directory                  System    Functional   Basis-Set
-            [2024/01/17 14:39:08] ───────────────────────────────────────────────────────────
-            [2024/01/17 14:39:08] root/SN2/M06-2X_TZ2P       SN2       M06-2X       TZ2P
-            [2024/01/17 14:39:08] root/NH3-BH3/BLYP_TZ2P     NH3-BH3   BLYP         TZ2P
-            [2024/01/17 14:39:08] root/NH3-BH3/M06-2X_TZ2P   NH3-BH3   M06-2X       TZ2P
-            [2024/01/17 14:39:08] root/SN2/BLYP_TZ2P         SN2       BLYP         TZ2P
-            [2024/01/17 14:39:08] root/NH3-BH3/BLYP_QZ4P     NH3-BH3   BLYP         QZ4P
-
-"""
-    # get the number and names of substitutions in the given pattern
-    substitutions = re.findall(r"{(\w+[+*?]?)}", pattern)
-    # the pattern should resolve to words and may contain - and _
-    # replace them here
-    for sub in substitutions:
-        quantifier = sub[-1] if sub[-1] in "+*?" else "+"
-        pattern = pattern.replace("{" + sub + "}", f"([a-zA-Z0-9_-]{quantifier})")
-
-    ret = results.Result()
-    # root dir can be any level deep. We should count how many directories are in root
-    root_length = len(split_all(root))
-    # get all subdirectories first, we can loop through them later
-    subdirs = get_subdirectories2(root, include_intermediates=True, max_depth=len(split_all(pattern)))
-    # remove the root from the subdirectories. We cannot use str.removeprefix because it was added in python 3.9
-    subdirs = [j(*split_all(subdir)[root_length:]) for subdir in subdirs if len(split_all(subdir)[root_length:]) > 0]
-    for subdir in subdirs:
-        # check if we get a match with our pattern
-        match = re.fullmatch(pattern, subdir)
-        if not match:
-            continue
-
-        p = j(root, subdir)
-        # get the group data and add it to the return dictionary. We skip the first group because it is the full directory path
-        ret[p] = results.Result(directory=p, **{substitutions[i]: match.group(i + 1) for i in range(len(substitutions))})
-
-    if not sort_by:
-        return ret
-
+    # sort the return object by whichever key was given
     return results.Result(sorted(ret.items(), key=lambda d: d[1][sort_by]))
 

--- a/src/tcutility/pathfunc.py
+++ b/src/tcutility/pathfunc.py
@@ -98,7 +98,7 @@ def get_subdirectories(root: str, include_intermediates: bool = False, max_depth
                 contents.append(entry.path)
                 break
 
-            sub_contents = list(get_subdirectories2(entry.path, include_intermediates=include_intermediates, _current_depth=_current_depth+1, max_depth=max_depth))
+            sub_contents = list(get_subdirectories(entry.path, include_intermediates=include_intermediates, _current_depth=_current_depth+1, max_depth=max_depth))
 
             if include_intermediates or len(sub_contents) == 0:
                 contents.append(entry.path)

--- a/src/tcutility/pathfunc.py
+++ b/src/tcutility/pathfunc.py
@@ -102,6 +102,75 @@ def get_subdirectories(root: str, include_intermediates: bool = False) -> List[s
     return subdirs
 
 
+def get_subdirectories2(root: str, include_intermediates: bool = False, _first_call: bool = True) -> List[str]:
+    """
+    Get all sub-directories of a root directory.
+
+    Args:
+        root: the root directory.
+        include_intermediates: whether to include intermediate sub-directories instead of only the lowest levels.
+
+    Returns:
+        A list of sub-directories with ``root`` included in the paths.
+
+    Example:
+        Given a file-structure as follows:
+
+        .. code-block::
+
+            root
+            |- subdir_a
+            |  |- subsubdir_b
+            |  |- subsubdir_c
+            |- subdir_b
+            |- subdir_c
+
+        Then we get the following outputs.
+
+        .. tabs::
+
+            .. group-tab:: Including intermediates
+
+                .. code-block:: python
+
+                    >>> get_subdirectories('root', include_intermediates=True)
+                    ['root',
+                     'root/subdir_a',
+                     'root/subdir_a/subsubdir_b',
+                     'root/subdir_a/subsubdir_c',
+                     'root/subdir_b',
+                     'root/subdir_c']
+
+            .. group-tab:: Excluding intermediates
+
+                .. code-block:: python
+
+                    >>> get_subdirectories('root', include_intermediates=False)
+                    ['root/subdir_a/subsubdir_b',
+                     'root/subdir_a/subsubdir_c',
+                     'root/subdir_b',
+                     'root/subdir_c']
+    """
+    contents = []
+    if _first_call and include_intermediates:
+        contents.append(root)
+
+    with os.scandir(root) as scanner:
+        for entry in scanner:
+            if entry.is_file():
+                continue
+
+            sub_contents = list(get_subdirectories2(entry.path, _first_call=False))
+
+            if include_intermediates or len(sub_contents) == 0:
+                contents.append(entry.path)
+
+            contents.extend(sub_contents)
+
+    return contents
+
+
+
 def match(root: str, pattern: str, sort_by: str = None) -> Dict[str, dict]:
     """
     Find and return information about subdirectories of a root that match a given pattern.
@@ -112,7 +181,6 @@ def match(root: str, pattern: str, sort_by: str = None) -> Dict[str, dict]:
             It should look similar to a format string, without the ``f`` in front of the string.
             Inside curly braces you can put a variable name, which you can later extract from the results.
             Anything inside curly braces will be matched to word characters (``[a-zA-Z0-9_-]``) including dashes and underscores.
-
         sort_by: the key to sort the results by. If not given, the results will be returned in the order they were found.
 
     Returns:
@@ -206,4 +274,102 @@ def path_depth(path: str) -> int:
     Calculate the depth of a given path.
     """
     return len(split_all(path))
+
+
+def match2(root: str, pattern: str, sort_by: str = None, as_generator: bool = False) -> Dict[str, dict]:
+    """
+    Find and return information about subdirectories of a root that match a given pattern.
+
+    Args:
+        root: the root of the subdirectories to look in.
+        pattern: a string specifying the pattern the subdirectories should correspond to.
+            It should look similar to a format string, without the ``f`` in front of the string.
+            Inside curly braces you can put a variable name, which you can later extract from the results.
+            Anything inside curly braces will be matched to word characters (``[a-zA-Z0-9_-]``) including dashes and underscores.
+        sort_by: the key to sort the results by. If not given, the results will be returned in the order they were found.
+
+    Returns:
+        A |Result| object containing the matched directories as keys and information (also |Result| object) about those matches as the values. Each information dictionary contains the variables given in the pattern.
+        E.g. using a pattern such as ``{a}/{b}/{c}`` will populate the ``info.a``, ``info.b`` and ``info.c`` keys of the info |Result| object.
+
+    Example:
+        Given a file-structure as follows:
+
+        .. code-block::
+
+            root
+            |- NH3-BH3
+            |   |- BLYP_QZ4P
+            |   |  |- extra_dir
+            |   |  |- blablabla
+            |   |
+            |   |- BLYP_TZ2P
+            |   |  |- another_dir
+            |   |
+            |   |- M06-2X_TZ2P
+            |
+            |- SN2
+            |   |- BLYP_TZ2P
+            |   |- M06-2X_TZ2P
+            |   |  |- M06-2X_TZ2P
+
+        We can run the following scripts to match the subdirectories.
+
+        .. code-block:: python
+
+            from tcutility import log
+            # get the matches, we want to extract the system name (NH3-BH3 or SN2)
+            # and the functional and basis-set
+            # we don't want the subdirectories
+            matches = match('root', '{system}/{functional}_{basis_set}')
+
+            # print the matches as a table
+            rows = []
+            for d, info in matches.items():
+                rows.append([d, info.system, info.functional, info.basis_set])
+
+            log.table(rows, ['Directory', 'System', 'Functional', 'Basis-Set'])
+
+        which prints
+
+        .. code-block::
+
+            [2024/01/17 14:39:08] Directory                  System    Functional   Basis-Set
+            [2024/01/17 14:39:08] ───────────────────────────────────────────────────────────
+            [2024/01/17 14:39:08] root/SN2/M06-2X_TZ2P       SN2       M06-2X       TZ2P
+            [2024/01/17 14:39:08] root/NH3-BH3/BLYP_TZ2P     NH3-BH3   BLYP         TZ2P
+            [2024/01/17 14:39:08] root/NH3-BH3/M06-2X_TZ2P   NH3-BH3   M06-2X       TZ2P
+            [2024/01/17 14:39:08] root/SN2/BLYP_TZ2P         SN2       BLYP         TZ2P
+            [2024/01/17 14:39:08] root/NH3-BH3/BLYP_QZ4P     NH3-BH3   BLYP         QZ4P
+
+"""
+    # get the number and names of substitutions in the given pattern
+    substitutions = re.findall(r"{(\w+[+*?]?)}", pattern)
+    # the pattern should resolve to words and may contain - and _
+    # replace them here
+    for sub in substitutions:
+        quantifier = sub[-1] if sub[-1] in "+*?" else "+"
+        pattern = pattern.replace("{" + sub + "}", f"([a-zA-Z0-9_-]{quantifier})")
+
+    ret = results.Result()
+    # root dir can be any level deep. We should count how many directories are in root
+    root_length = len(split_all(root))
+    # get all subdirectories first, we can loop through them later
+    subdirs = get_subdirectories2(root, include_intermediates=True)
+    # remove the root from the subdirectories. We cannot use str.removeprefix because it was added in python 3.9
+    subdirs = [j(*split_all(subdir)[root_length:]) for subdir in subdirs if len(split_all(subdir)[root_length:]) > 0]
+    for subdir in subdirs:
+        # check if we get a match with our pattern
+        match = re.fullmatch(pattern, subdir)
+        if not match:
+            continue
+
+        p = j(root, subdir)
+        # get the group data and add it to the return dictionary. We skip the first group because it is the full directory path
+        ret[p] = results.Result(directory=p, **{substitutions[i]: match.group(i + 1) for i in range(len(substitutions))})
+
+    if not sort_by:
+        return ret
+
+    return results.Result(sorted(ret.items(), key=lambda d: d[1][sort_by]))
 

--- a/src/tcutility/pathfunc.py
+++ b/src/tcutility/pathfunc.py
@@ -96,7 +96,7 @@ def get_subdirectories(root: str, include_intermediates: bool = False, max_depth
 
             if _current_depth == max_depth:
                 contents.append(entry.path)
-                break
+                continue
 
             sub_contents = list(get_subdirectories(entry.path, include_intermediates=include_intermediates, _current_depth=_current_depth+1, max_depth=max_depth))
 

--- a/src/tcutility/pathfunc.py
+++ b/src/tcutility/pathfunc.py
@@ -160,17 +160,16 @@ def get_subdirectories2(root: str, include_intermediates: bool = False, max_dept
             if entry.is_file():
                 continue
 
-            if _curent_depth + 1 == max_depth:
+            if _current_depth == max_depth:
                 contents.append(entry.path)
+                break
 
-            else:
-                sub_contents = list(get_subdirectories2(entry.path, _curent_depth=_curent_depth+1))
             sub_contents = list(get_subdirectories2(entry.path, include_intermediates=include_intermediates, _current_depth=_current_depth+1, max_depth=max_depth))
 
-                if include_intermediates or len(sub_contents) == 0:
-                    contents.append(entry.path)
+            if include_intermediates or len(sub_contents) == 0:
+                contents.append(entry.path)
 
-                contents.extend(sub_contents)
+            contents.extend(sub_contents)
 
     return contents
 

--- a/src/tcutility/pathfunc.py
+++ b/src/tcutility/pathfunc.py
@@ -102,7 +102,7 @@ def get_subdirectories(root: str, include_intermediates: bool = False) -> List[s
     return subdirs
 
 
-def get_subdirectories2(root: str, include_intermediates: bool = False, max_depth: int = None, _curent_depth: int = 0) -> List[str]:
+def get_subdirectories2(root: str, include_intermediates: bool = False, max_depth: int = None, _current_depth: int = 0) -> List[str]:
     """
     Get all sub-directories of a root directory.
 
@@ -152,7 +152,7 @@ def get_subdirectories2(root: str, include_intermediates: bool = False, max_dept
                      'root/subdir_c']
     """
     contents = []
-    if _curent_depth == 0 and include_intermediates:
+    if _current_depth == 0 and include_intermediates:
         contents.append(root)
 
     with os.scandir(root) as scanner:

--- a/src/tcutility/pathfunc.py
+++ b/src/tcutility/pathfunc.py
@@ -165,6 +165,7 @@ def get_subdirectories2(root: str, include_intermediates: bool = False, max_dept
 
             else:
                 sub_contents = list(get_subdirectories2(entry.path, _curent_depth=_curent_depth+1))
+            sub_contents = list(get_subdirectories2(entry.path, include_intermediates=include_intermediates, _current_depth=_current_depth+1, max_depth=max_depth))
 
                 if include_intermediates or len(sub_contents) == 0:
                     contents.append(entry.path)

--- a/src/tcutility/pathfunc.py
+++ b/src/tcutility/pathfunc.py
@@ -194,7 +194,7 @@ def match(root: str, pattern: str, sort_by: str = None) -> Dict[str, dict]:
     # root dir can be any level deep. We should count how many directories are in root
     root_length = len(split_all(root))
     # get all subdirectories first, we can loop through them later
-    subdirs = get_subdirectories(root, include_intermediates=True, max_depth=len(split_all(pattern)))
+    subdirs = get_subdirectories(root, include_intermediates=False, max_depth=len(split_all(pattern))-1)
     # remove the root from the subdirectories. We cannot use str.removeprefix because it was added in python 3.9
     subdirs = [j(*split_all(subdir)[root_length:]) for subdir in subdirs if len(split_all(subdir)[root_length:]) > 0]
     for subdir in subdirs:

--- a/test/test_pathfunc.py
+++ b/test/test_pathfunc.py
@@ -63,7 +63,7 @@ def test_get_subdirectories(temp_dir):
         f'{temp_dir}/subdir_b',
         f'{temp_dir}/subdir_c'
     }
-    assert pathfunc.get_subdirectories(temp_dir) == expected
+    assert sorted(pathfunc.get_subdirectories(temp_dir)) == sorted(expected)
 
 
 def test_get_subdirectories2(temp_dir):
@@ -75,7 +75,7 @@ def test_get_subdirectories2(temp_dir):
         f'{temp_dir}/subdir_b',
         f'{temp_dir}/subdir_c'
     }
-    assert pathfunc.get_subdirectories(temp_dir, include_intermediates=True) == expected
+    assert sorted(pathfunc.get_subdirectories(temp_dir, include_intermediates=True)) == sorted(expected)
 
 
 def test_match(temp_dir2):


### PR DESCRIPTION
In the old version of `tcutility.pathfunc` we used the `os.listdir` function which is much slower than using the `os.scandir` class. Using this new method we find speed-ups of up to 4x for the `pathfunc.match` and `pathfunc.get_subdirectories` functions.