### PR TITLE
Small speed-ups for `pathfunc.match`

### DIFF
--- a/src/tcutility/pathfunc.py
+++ b/src/tcutility/pathfunc.py
@@ -190,7 +190,7 @@ def match(root: str, pattern: str, sort_by: str = None) -> Dict[str, dict]:
     # given the substitutions we build a regex pattern and a glob pattern
     glob_pattern = pattern
     for sub in substitutions:
-        pattern = pattern.replace("{" + sub + "}", f"([a-zA-Z0-9_-]+)")
+        pattern = pattern.replace("{" + sub + "}", "([a-zA-Z0-9_-]+)")
         glob_pattern = glob_pattern.replace("{" + sub + "}", "*")
 
     # get all applicable subdirectories

--- a/src/tcutility/pathfunc.py
+++ b/src/tcutility/pathfunc.py
@@ -181,7 +181,6 @@ def match(root: str, pattern: str, sort_by: str = None) -> Dict[str, dict]:
             [2024/01/17 14:39:08] root/NH3-BH3/M06-2X_TZ2P   NH3-BH3   M06-2X       TZ2P
             [2024/01/17 14:39:08] root/SN2/BLYP_TZ2P         SN2       BLYP         TZ2P
             [2024/01/17 14:39:08] root/NH3-BH3/BLYP_QZ4P     NH3-BH3   BLYP         QZ4P
-
 """
     # get the number and names of substitutions in the given pattern
     substitutions = re.findall(r"{(\w+)}", pattern)
@@ -194,7 +193,7 @@ def match(root: str, pattern: str, sort_by: str = None) -> Dict[str, dict]:
         glob_pattern = glob_pattern.replace("{" + sub + "}", "*")
 
     # get all applicable subdirectories
-    subdirs = glob.glob(glob_pattern, root_dir=root)
+    subdirs = glob.glob(os.path.join(root, glob_pattern))
 
     # compile a regular expression pattern to match with later
     regex = re.compile(pattern)
@@ -202,6 +201,8 @@ def match(root: str, pattern: str, sort_by: str = None) -> Dict[str, dict]:
     # go through all applicable subdirectories and retrieve the information we want
     ret = results.Result()
     for subdir in subdirs:
+        # subdir = os.path.relpath(subdir, root)
+        subdir = subdir.removeprefix(f'{root}/')
         p = j(root, subdir)
         re_match = regex.fullmatch(subdir)
         ret[p] = results.Result(**{substitutions[i]: re_match.group(i + 1) for i in range(len(substitutions))})

--- a/src/tcutility/pathfunc.py
+++ b/src/tcutility/pathfunc.py
@@ -202,7 +202,7 @@ def match(root: str, pattern: str, sort_by: str = None) -> Dict[str, dict]:
     ret = results.Result()
     for subdir in subdirs:
         # subdir = os.path.relpath(subdir, root)
-        subdir = subdir.removeprefix(f'{root}/')
+        subdir = subdir[len(f'{root}/'):]
         p = j(root, subdir)
         re_match = regex.fullmatch(subdir)
         ret[p] = results.Result(**{substitutions[i]: re_match.group(i + 1) for i in range(len(substitutions))})


### PR DESCRIPTION
I implemented a new version of `match` using the `glob` python module. From testing the speed-ups are limited, but I think the implementation is much simpler now. From testing I find a speedup of around 1.2x:

```python
from tcutility import timer, pathfunc

for _ in range(1000):
    with timer.timer('Using scandir'):
        res_old = pathfunc.match('calcs_test', '{donor}-{acceptor}/{level_of_theory}')

    with timer.timer('Using glob'):
        res_new = pathfunc.match2('calcs_test', '{donor}-{acceptor}/{level_of_theory}')

    assert sorted(res_old) == sorted(res_new)
```
yields
```
[2025/02/17 19:05:38] Function        Calls   Mean (s)   Time Spent (s)   Rel. Time
[2025/02/17 19:05:38] ──────────────────────────────────────────────────────────────
[2025/02/17 19:05:38] Using glob      1000    0.003      2.933             46%     
[2025/02/17 19:05:38] Using scandir   1000    0.003      3.395             53%     
[2025/02/17 19:05:38] ──────────────────────────────────────────────────────────────
[2025/02/17 19:05:38] TOTAL                              6.347            100%     
[2025/02/17 19:05:38] 
```