### PR TITLE
Added reading of system settings from extended XYZ-files

### DIFF
--- a/src/tcutility/connect.py
+++ b/src/tcutility/connect.py
@@ -27,7 +27,8 @@ class Connection:
         This class is a context manager and the ``with``-syntax should be used to open and automatically close connections.
         For example, to open a connection to the Snellius supercomputer we use the following code:
 
-        .. codeblock::
+        .. code-block::
+        
             from tcutility.connect import Connection
             
             with Connection('username@server.address.nl') as server:

--- a/src/tcutility/job/ams.py
+++ b/src/tcutility/job/ams.py
@@ -248,8 +248,9 @@ class AMSJob(Job):
         Set the version of AMS to use for the calculation.
         Which versions are available depends on the location you are currently in.
         We currently support the following versions:
-            On Snellius: ``2023`` and ``2024``.
-            On Bazis: ``2021``, ``2022``, ``2023`` and ``2024``.
+
+            -    On Snellius: ``2023`` and ``2024``.
+            -    On Bazis: ``2021``, ``2022``, ``2023`` and ``2024``.
         '''
         server = self._select_server()
         if isinstance(server, connect.Local):


### PR DESCRIPTION
You can now give charges, spin-polarizations and solvents to xyz-files. These will be read before starting a calculation and added as settings to the job.