### PR TITLE
Added missing `postamble_defaults` attribute to `connect.Server` classes

### DIFF
--- a/src/tcutility/connect.py
+++ b/src/tcutility/connect.py
@@ -270,6 +270,7 @@ class Server(Connection):
     server = None
     sbatch_defaults = {}
     preamble_defaults = {}
+    postamble_defaults = {}
     program_modules = {}
 
     def __init__(self, username=None):
@@ -283,6 +284,7 @@ class Local:
     server = None
     sbatch_defaults = {}
     preamble_defaults = {}
+    postamble_defaults = {}
     program_modules = {}
 
     def __init__(self):


### PR DESCRIPTION
Fixed an issue related to an attribute not being present during job setup