### PR TITLE
Renamed the `tc` CLI to `tcutility`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ exclude = [
 namespaces = false # to disable scanning PEP 420 namespaces (true by default)
 
 [project.scripts]
-tc = "tcutility.cli_scripts.tcparser:tc"
+tcutility = "tcutility.cli_scripts.tcparser:tc"
 
 [project.optional-dependencies]
 docs = [

--- a/src/tcutility/cli_scripts/tcparser.py
+++ b/src/tcutility/cli_scripts/tcparser.py
@@ -9,14 +9,14 @@ from tcutility.cli_scripts.resize_figures import resize
 
 
 @click.group()
-def tc():
+def tcutility():
     """TCutility command line interface."""
     pass
 
 
-tc.add_command(read_results, name="read")
-tc.add_command(optimize_geometry, name="optimize")
-tc.add_command(generate_citations, name="cite")
-tc.add_command(calculate_geometry_parameter, name="geo")
-tc.add_command(concatenate_irc_paths, name="concat-irc")
-tc.add_command(resize, name="resize")
+tcutility.add_command(read_results, name="read")
+tcutility.add_command(optimize_geometry, name="optimize")
+tcutility.add_command(generate_citations, name="cite")
+tcutility.add_command(calculate_geometry_parameter, name="geo")
+tcutility.add_command(concatenate_irc_paths, name="concat-irc")
+tcutility.add_command(resize, name="resize")

--- a/src/tcutility/job/generic.py
+++ b/src/tcutility/job/generic.py
@@ -193,7 +193,7 @@ class Job:
 
         if self.delete_on_fail:
             self.add_postamble("# this will delete the calculation if it failed")
-            self.add_postamble(f"if [[ `tc read -s {self.workdir}` = FAILED || `tc read -s {self.workdir}` = UNKNOWN ]]; then rm -r {self.workdir}; fi;")
+            self.add_postamble(f"if [[ `tcutility read -s {self.workdir}` = FAILED || `tcutility read -s {self.workdir}` = UNKNOWN ]]; then rm -r {self.workdir}; fi;")
 
         for postscript in self._postscripts:
             self._postambles.append(f'{_python_path(server)} {postscript[0]} {" ".join(postscript[1])}')

--- a/src/tcutility/job/generic.py
+++ b/src/tcutility/job/generic.py
@@ -119,13 +119,11 @@ class Job:
                 if not res.fatal:
                     return True
 
-            res = server.execute(f'tc read -s {j(server.pwd(), self.rundir, self.name)}')
+            res = server.execute(f'tcutility read -s {j(server.pwd(), self.rundir, self.name)}')
             if res in ['SUCCESS', 'SUCCESS(W)', 'COMPLETING', 'CONFIGURING', 'PENDING', 'RUNNING']:
                 return True
 
         return False
-        # res = results.quick_status(self.workdir)
-        # return not res.fatal
 
     def in_queue(self):
         """


### PR DESCRIPTION
There was an issue of some systems already having defined a `tc` CLI program. I have renamed our `tc` CLI to `tcutility` to avoid problems like this.