### PR TITLE
Added the `grid_extend` parameter to `gridsize` method of DensfJob and fixed an issue with MOs with differing spins.

### DIFF
--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -815,7 +815,7 @@ class DensfJob(Job):
     def __str__(self):
         return f"Densf({self.target}), running in {self.workdir}"
 
-    def gridsize(self, size="medium"):
+    def gridsize(self, size="medium", grid_extend=7.5):
         """
         Set the size of the grid to be used by Densf.
 
@@ -824,9 +824,10 @@ class DensfJob(Job):
         """
         spell_check.check(size, ["coarse", "medium", "fine"], ignore_case=True)
         self.settings.grid = size
+        self.settings.grid_extend = grid_extend
 
     def grid(self, args):
-        self.settings.grid = '\n' + '\n'.join(args)
+        self.settings.grid = '\n' + '\n'.join(args) + 'EXTEND 7.5\n'
 
     def orbital(self, orbital: "pyfmo.orbitals.sfo.SFO" or "pyfmo.orbitals.mo.MO"):  # noqa: F821
         """
@@ -880,10 +881,15 @@ class DensfJob(Job):
             inpf.write(f"ADFFile {os.path.abspath(self.settings.ADFFile)}\n")
             inpf.write(f"GRID {self.settings.grid}\n")
             inpf.write("END\n")
+            if self.settings.grid_extend:
+                inpf.write(f"EXTEND {self.settings.grid_extend}\n")
 
             if len(self._mos) > 0:
                 inpf.write("Orbitals SCF\n")
                 for orb in self._mos:
+                    if orb.spin in ['A', 'B']:
+                        spin = {'A': 'alpha', 'B': 'beta'}[orb.spin]
+                        inpf.write(f"    {spin}\n")
                     inpf.write(f"    {orb.symmetry} {orb.symmetry_index}\n")
                 inpf.write("END\n")
 


### PR DESCRIPTION
I have added the option to extend the grid for `DensfJob` calculations. This alows us to easily increase the size of generated grids. By default it is set to 7.5 bohr. This is also the standard for the densf calculations used by AMS in the AMSView program. #462 

Secondly there was an issue with the generation of cube files for unrestricted MOs. #463 