### PR TITLE
Small improvements to the `analysis.pyfrag` module

### DIFF
--- a/src/tcutility/analysis/pyfrag.py
+++ b/src/tcutility/analysis/pyfrag.py
@@ -118,8 +118,7 @@ class PyFragResult:
         except ModuleNotFoundError:
             raise ModuleNotFoundError('The pyfmo module could not be loaded. To gain access please contact the TCutility developers!')
 
-
-        return [pyfmo.orbitals2.objects.Orbitals(res[calc].files['adf.rkf']) for res in self._step_results]
+        return [pyfmo.Orbitals(res[calc].files['adf.rkf']) for res in self._step_results]
 
 
 if __name__ == '__main__':

--- a/src/tcutility/analysis/pyfrag.py
+++ b/src/tcutility/analysis/pyfrag.py
@@ -54,6 +54,11 @@ class PyFragResult:
         g = np.array([tcutility.geometry.parameter(res[calc].molecule.input, *args, **kwargs) for res in self._step_results])
         return g[self._order][self._mask[self._order]]
 
+    def get_molecules(self):
+        mols = [res[calc].molecule.input for res in self._step_results]
+        return mols
+        return [mols[int(i)] for i in np.array(self._order)[self._mask[self._order]]]
+
     def sort_by(self, val: str or list, calc: str = 'complex'):
         if isinstance(val, str):
             val = self.get_property(val, calc=calc)


### PR DESCRIPTION
I have added the `get_molecules` method and we now use the correct `pyfmo.Orbitals` class.