### PR TITLE
General optimizations speed related to job setup and status checking

### DIFF
--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -600,14 +600,14 @@ class ADFFragmentJob(ADFJob):
 
             if child.can_skip():
                 log.flow(log.Emojis.warning + " Already ran, skipping", ["straight", "end"], level=10)
-                log.flow(, level=10)
+                log.flow(level=10)
             else:
                 log.flow(log.Emojis.good + " Submitting", ["straight", "end"], level=10)
                 [child._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                 child.run()
                 self.dependency(child)
                 log.flow(f"SlurmID:  {child.slurm_job_id}", ["straight", "skip", "end"], level=10)
-                log.flow(, level=10)
+                log.flow(level=10)
 
             if self.decompose_elstat:
                 child_STOFIT = ADFJob(child)
@@ -625,14 +625,14 @@ class ADFFragmentJob(ADFJob):
 
                 if child_STOFIT.can_skip():
                     log.flow(log.Emojis.warning + " Already ran, skipping", ["straight", "end"], level=10)
-                    log.flow(, level=10)
+                    log.flow(level=10)
                 else:
                     log.flow(log.Emojis.good + " Submitting", ["straight", "end"], level=10)
                     [child_STOFIT._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                     child_STOFIT.run()
                     self.dependency(child_STOFIT)
                     log.flow(f"SlurmID:  {child_STOFIT.slurm_job_id}", ["straight", "skip", "end"], level=10)
-                    log.flow(, level=10)
+                    log.flow(level=10)
 
                 child_NoElectrons = ADFJob(child)
                 child_NoElectrons.name += "_NoElectrons"
@@ -653,14 +653,14 @@ class ADFFragmentJob(ADFJob):
 
                 if child_NoElectrons.can_skip():
                     log.flow(log.Emojis.warning + " Already ran, skipping", ["straight", "end"], level=10)
-                    log.flow(, level=10)
+                    log.flow(level=10)
                 else:
                     log.flow(log.Emojis.good + " Submitting", ["straight", "end"], level=10)
                     [child_NoElectrons._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                     child_NoElectrons.run()
                     self.dependency(child_NoElectrons)
                     log.flow(f"SlurmID:  {child_NoElectrons.slurm_job_id}", ["straight", "skip", "end"], level=10)
-                    log.flow(, level=10)
+                    log.flow(level=10)
 
         # in the parent job the atoms should have the region and adf.f defined as options
         atom_lines = []
@@ -685,7 +685,7 @@ class ADFFragmentJob(ADFJob):
 
         super().run()
         log.flow(f"SlurmID: {self.slurm_job_id}", ["straight", "end"], level=10)
-        log.flow(, level=10)
+        log.flow(level=10)
 
         # also do the calculation with SCF cycles set to 1 if desired
         if self.scf0_calculation:
@@ -698,7 +698,7 @@ class ADFFragmentJob(ADFJob):
 
             super().run()
             log.flow(f"SlurmID: {self.slurm_job_id}", ["straight", "end"], level=10)
-            log.flow(, level=10)
+            log.flow(level=10)
 
             # reset the SCF iterations
             self.SCF(iterations=old_iters)
@@ -729,7 +729,7 @@ class ADFFragmentJob(ADFJob):
             log.flow(log.Emojis.good + " Submitting complex with STOFIT", ["split"], level=10)
             super().run()
             log.flow(f"SlurmID: {self.slurm_job_id}", ["straight", "end"], level=10)
-            log.flow(, level=10)
+            log.flow(level=10)
 
             for frag in frag_names:
                 # other_frags stores fragment names for fragments that keep their electrons
@@ -766,7 +766,7 @@ class ADFFragmentJob(ADFJob):
                 [self._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                 super().run()
                 log.flow(f"SlurmID: {self.slurm_job_id}", ["straight", "end"], level=10)
-                log.flow(, level=10)
+                log.flow(level=10)
 
         if self.counter_poise:
             self.settings.input.ams.EngineDebugging.pop('AlwaysClaimSuccess', None)
@@ -800,7 +800,7 @@ class ADFFragmentJob(ADFJob):
                 [self._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                 super().run()
                 log.flow(f'SlurmID: {self.slurm_job_id}', ['straight', 'end'], level=10)
-                log.flow(, level=10)
+                log.flow(level=10)
 
         log.flow(log.Emojis.finish + ' Done, bye!', ['startinv'], level=10)
 

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -519,6 +519,7 @@ class ADFFragmentJob(ADFJob):
   End
         """
 
+    @timer.timer
     def run(self):
         """
         Run the ``ADFFragmentJob``. This involves setting up the calculations for each fragment as well as the parent job.

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -176,7 +176,7 @@ class ADFJob(AMSJob):
         self._functional = functional
 
         if functional == "r2SCAN-3c" and self._basis_set != "mTZ2P":
-            log.info(f"Switching basis set from {self._basis_set} to mTZ2P for r2SCAN-3c.")
+            log.debug(f"Switching basis set from {self._basis_set} to mTZ2P for r2SCAN-3c.")
             self.basis_set("mTZ2P")
 
         if functional == "SSB-D":
@@ -535,17 +535,17 @@ class ADFFragmentJob(ADFJob):
                 raise
 
         mol_str = " + ".join([formula.molecule(child._molecule) for child in self.child_jobs.values()])
-        log.flow(f"ADFFragmentJob [{mol_str}]", ["start"])
+        log.flow(f"ADFFragmentJob [{mol_str}]", ["start"], level=10)
         # obtain some system wide properties of the molecules
         charge = sum([child.settings.input.ams.System.charge or 0 for child in self.child_jobs.values()])
         unrestricted = any([(child.settings.input.adf.Unrestricted or "no").lower() == "yes" for child in self.child_jobs.values()]) or (self.settings.input.adf.Unrestricted or "no").lower() == "yes"
         spinpol = sum([child.settings.input.adf.SpinPolarization or 0 for child in self.child_jobs.values()])
-        log.flow(f"Level:             {self._functional}/{self._basis_set}")
-        log.flow(f"Solvent:           {self._solvent}")
-        log.flow(f"Charge:            {charge}", ["straight"])
-        log.flow(f"Unrestricted:      {unrestricted}", ["straight"])
-        log.flow(f"Spin-Polarization: {spinpol}", ["straight"])
-        log.flow()
+        log.flow(f"Level:             {self._functional}/{self._basis_set}", level=10)
+        log.flow(f"Solvent:           {self._solvent}", level=10)
+        log.flow(f"Charge:            {charge}", ["straight"], level=10)
+        log.flow(f"Unrestricted:      {unrestricted}", ["straight"], level=10)
+        log.flow(f"Spin-Polarization: {spinpol}", ["straight"], level=10)
+        log.flow(level=10)
 
         # this job and all its children should have the same value for unrestricted
         # [child.unrestricted(unrestricted) for child in self.child_jobs.values()]
@@ -593,21 +593,21 @@ class ADFFragmentJob(ADFJob):
             # recast the plams.Settings object into a Result object as that is what run expects
             child.settings = results.Result(child_setts[child_name])
 
-            log.flow(f'Fragment ({i}/{len(self.child_jobs)}) {child_name} [{formula.molecule(child._molecule)}]', ['split'])
-            log.flow(f'Charge:            {child.settings.input.ams.System.charge or 0}', ['straight', 'straight'])
-            log.flow(f'Spin-Polarization: {child.settings.input.adf.SpinPolarization or 0}', ['straight', 'straight'])
-            log.flow(f'Work dir:          {child.workdir}', ['straight', 'straight'])
+            log.flow(f'Fragment ({i}/{len(self.child_jobs)}) {child_name} [{formula.molecule(child._molecule)}]', ['split'], level=10)
+            log.flow(f'Charge:            {child.settings.input.ams.System.charge or 0}', ['straight', 'straight'], level=10)
+            log.flow(f'Spin-Polarization: {child.settings.input.adf.SpinPolarization or 0}', ['straight', 'straight'], level=10)
+            log.flow(f'Work dir:          {child.workdir}', ['straight', 'straight'], level=10)
 
             if child.can_skip():
-                log.flow(log.Emojis.warning + " Already ran, skipping", ["straight", "end"])
-                log.flow()
+                log.flow(log.Emojis.warning + " Already ran, skipping", ["straight", "end"], level=10)
+                log.flow(, level=10)
             else:
-                log.flow(log.Emojis.good + " Submitting", ["straight", "end"])
+                log.flow(log.Emojis.good + " Submitting", ["straight", "end"], level=10)
                 [child._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                 child.run()
                 self.dependency(child)
-                log.flow(f"SlurmID:  {child.slurm_job_id}", ["straight", "skip", "end"])
-                log.flow()
+                log.flow(f"SlurmID:  {child.slurm_job_id}", ["straight", "skip", "end"], level=10)
+                log.flow(, level=10)
 
             if self.decompose_elstat:
                 child_STOFIT = ADFJob(child)
@@ -618,21 +618,21 @@ class ADFFragmentJob(ADFJob):
                 child_STOFIT.settings.input.adf.pop("NumericalQuality")
                 child_STOFIT.settings.input.adf.BeckeGrid.Quality = "Excellent"
 
-                log.flow(f'Fragment ({i}/{len(self.child_jobs)}) {child_name} [{formula.molecule(child._molecule)}] with STOFIT', ['split'])
-                log.flow(f'Charge:            {child_STOFIT.settings.input.ams.System.charge or 0}', ['straight', 'straight'])
-                log.flow(f'Spin-Polarization: {child_STOFIT.settings.input.adf.SpinPolarization or 0}', ['straight', 'straight'])
-                log.flow(f'Work dir:          {child_STOFIT.workdir}', ['straight', 'straight'])
+                log.flow(f'Fragment ({i}/{len(self.child_jobs)}) {child_name} [{formula.molecule(child._molecule)}] with STOFIT', ['split'], level=10)
+                log.flow(f'Charge:            {child_STOFIT.settings.input.ams.System.charge or 0}', ['straight', 'straight'], level=10)
+                log.flow(f'Spin-Polarization: {child_STOFIT.settings.input.adf.SpinPolarization or 0}', ['straight', 'straight'], level=10)
+                log.flow(f'Work dir:          {child_STOFIT.workdir}', ['straight', 'straight'], level=10)
 
                 if child_STOFIT.can_skip():
-                    log.flow(log.Emojis.warning + " Already ran, skipping", ["straight", "end"])
-                    log.flow()
+                    log.flow(log.Emojis.warning + " Already ran, skipping", ["straight", "end"], level=10)
+                    log.flow(, level=10)
                 else:
-                    log.flow(log.Emojis.good + " Submitting", ["straight", "end"])
+                    log.flow(log.Emojis.good + " Submitting", ["straight", "end"], level=10)
                     [child_STOFIT._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                     child_STOFIT.run()
                     self.dependency(child_STOFIT)
-                    log.flow(f"SlurmID:  {child_STOFIT.slurm_job_id}", ["straight", "skip", "end"])
-                    log.flow()
+                    log.flow(f"SlurmID:  {child_STOFIT.slurm_job_id}", ["straight", "skip", "end"], level=10)
+                    log.flow(, level=10)
 
                 child_NoElectrons = ADFJob(child)
                 child_NoElectrons.name += "_NoElectrons"
@@ -646,21 +646,21 @@ class ADFFragmentJob(ADFJob):
                 child_NoElectrons.settings.input.adf.BeckeGrid.Quality = "Excellent"
 
 
-                log.flow(f'Fragment ({i}/{len(self.child_jobs)}) {child_name} [{formula.molecule(child._molecule)}] without Electrons', ['split'])
-                log.flow(f'Charge:            {child_NoElectrons.settings.input.ams.System.charge or 0}', ['straight', 'straight'])
-                log.flow(f'Spin-Polarization: {child_NoElectrons.settings.input.adf.SpinPolarization or 0}', ['straight', 'straight'])
-                log.flow(f'Work dir:          {child_NoElectrons.workdir}', ['straight', 'straight'])
+                log.flow(f'Fragment ({i}/{len(self.child_jobs)}) {child_name} [{formula.molecule(child._molecule)}] without Electrons', ['split'], level=10)
+                log.flow(f'Charge:            {child_NoElectrons.settings.input.ams.System.charge or 0}', ['straight', 'straight'], level=10)
+                log.flow(f'Spin-Polarization: {child_NoElectrons.settings.input.adf.SpinPolarization or 0}', ['straight', 'straight'], level=10)
+                log.flow(f'Work dir:          {child_NoElectrons.workdir}', ['straight', 'straight'], level=10)
 
                 if child_NoElectrons.can_skip():
-                    log.flow(log.Emojis.warning + " Already ran, skipping", ["straight", "end"])
-                    log.flow()
+                    log.flow(log.Emojis.warning + " Already ran, skipping", ["straight", "end"], level=10)
+                    log.flow(, level=10)
                 else:
-                    log.flow(log.Emojis.good + " Submitting", ["straight", "end"])
+                    log.flow(log.Emojis.good + " Submitting", ["straight", "end"], level=10)
                     [child_NoElectrons._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                     child_NoElectrons.run()
                     self.dependency(child_NoElectrons)
-                    log.flow(f"SlurmID:  {child_NoElectrons.slurm_job_id}", ["straight", "skip", "end"])
-                    log.flow()
+                    log.flow(f"SlurmID:  {child_NoElectrons.slurm_job_id}", ["straight", "skip", "end"], level=10)
+                    log.flow(, level=10)
 
         # in the parent job the atoms should have the region and adf.f defined as options
         atom_lines = []
@@ -681,11 +681,11 @@ class ADFFragmentJob(ADFJob):
         # run this job
         self.rundir = j(self.rundir, old_name)
         self.name = "complex"
-        log.flow(log.Emojis.good + " Submitting parent job", ["split"])
+        log.flow(log.Emojis.good + " Submitting parent job", ["split"], level=10)
 
         super().run()
-        log.flow(f"SlurmID: {self.slurm_job_id}", ["straight", "end"])
-        log.flow()
+        log.flow(f"SlurmID: {self.slurm_job_id}", ["straight", "end"], level=10)
+        log.flow(, level=10)
 
         # also do the calculation with SCF cycles set to 1 if desired
         if self.scf0_calculation:
@@ -694,11 +694,11 @@ class ADFFragmentJob(ADFJob):
             # we must repopulate the sbatch settings for the new run
             [self._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
             self.name = "complex_SCF0"
-            log.flow(log.Emojis.good + " Submitting extra job with 0 SCF iterations", ["split"])
+            log.flow(log.Emojis.good + " Submitting extra job with 0 SCF iterations", ["split"], level=10)
 
             super().run()
-            log.flow(f"SlurmID: {self.slurm_job_id}", ["straight", "end"])
-            log.flow()
+            log.flow(f"SlurmID: {self.slurm_job_id}", ["straight", "end"], level=10)
+            log.flow(, level=10)
 
             # reset the SCF iterations
             self.SCF(iterations=old_iters)
@@ -726,10 +726,10 @@ class ADFFragmentJob(ADFJob):
             self.settings.input.adf.STOFIT = ""
             self.settings.input.adf.PRINT += " Elstat"
             [self._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
-            log.flow(log.Emojis.good + " Submitting complex with STOFIT", ["split"])
+            log.flow(log.Emojis.good + " Submitting complex with STOFIT", ["split"], level=10)
             super().run()
-            log.flow(f"SlurmID: {self.slurm_job_id}", ["straight", "end"])
-            log.flow()
+            log.flow(f"SlurmID: {self.slurm_job_id}", ["straight", "end"], level=10)
+            log.flow(, level=10)
 
             for frag in frag_names:
                 # other_frags stores fragment names for fragments that keep their electrons
@@ -762,11 +762,11 @@ class ADFFragmentJob(ADFJob):
                 total_spin_polarization = other_spin_polarization + (elstat_jobs["frag_" + frag + "_NoElectrons"].settings.input.adf.SpinPolarization)
                 self.spin_polarization(total_spin_polarization)
 
-                log.flow(log.Emojis.good + f" Submitting complex with 0 electrons in fragment {frag}", ["split"])
+                log.flow(log.Emojis.good + f" Submitting complex with 0 electrons in fragment {frag}", ["split"], level=10)
                 [self._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                 super().run()
-                log.flow(f"SlurmID: {self.slurm_job_id}", ["straight", "end"])
-                log.flow()
+                log.flow(f"SlurmID: {self.slurm_job_id}", ["straight", "end"], level=10)
+                log.flow(, level=10)
 
         if self.counter_poise:
             self.settings.input.ams.EngineDebugging.pop('AlwaysClaimSuccess', None)
@@ -796,13 +796,13 @@ class ADFFragmentJob(ADFJob):
 
                 # we must repopulate the sbatch settings for the new run
                 self.name = f'complex_{frag}_Ghost'
-                log.flow(log.Emojis.good + f' Submitting {frag} with the basis-set of the complex', ['split'])
+                log.flow(log.Emojis.good + f' Submitting {frag} with the basis-set of the complex', ['split'], level=10)
                 [self._sbatch.pop(key, None) for key in ["D", "chdir", "J", "job_name", "o", "output"]]
                 super().run()
-                log.flow(f'SlurmID: {self.slurm_job_id}', ['straight', 'end'])
-                log.flow()
+                log.flow(f'SlurmID: {self.slurm_job_id}', ['straight', 'end'], level=10)
+                log.flow(, level=10)
 
-        log.flow(log.Emojis.finish + ' Done, bye!', ['startinv'])
+        log.flow(log.Emojis.finish + ' Done, bye!', ['startinv'], level=10)
 
 
 class DensfJob(Job):

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -49,7 +49,7 @@ class ADFJob(AMSJob):
         spell_check.check(typ, data.basis_sets.available_basis_sets["ADF"], ignore_case=True)
         spell_check.check(core, ["None", "Small", "Large"], ignore_case=True)
         if self._functional == "r2SCAN-3c" and typ != "mTZ2P":
-            log.warn(f"Basis set {typ} is not allowed with r2SCAN-3c, switching to mTZ2P.")
+            log.debug(f"Basis set {typ} is not allowed with r2SCAN-3c, switching to mTZ2P.")
             typ = "mTZ2P"
         self._basis_set = typ
         self._core = core
@@ -527,7 +527,7 @@ class ADFFragmentJob(ADFJob):
         # check if the user defined fragments for this job
 
         if len(self.child_jobs) == 0:
-            log.warn("Fragments were not specified yet, trying to read them from the xyz file ...")
+            log.debug("Fragments were not specified yet, trying to read them from the xyz file ...")
 
             # if they did not define the fragments, try to guess them using the xyz-file
             if not self.guess_fragments():

--- a/src/tcutility/job/adf.py
+++ b/src/tcutility/job/adf.py
@@ -2,7 +2,7 @@ import os
 
 from scm import plams
 from typing import Dict, Optional, TYPE_CHECKING
-from tcutility import data, formula, log, molecule, results, spell_check
+from tcutility import data, formula, log, molecule, results, spell_check, timer
 from tcutility.errors import TCCompDetailsError, TCJobError
 from tcutility.job.ams import AMSJob
 from tcutility.job.generic import Job
@@ -805,7 +805,6 @@ class ADFFragmentJob(ADFJob):
         log.flow(log.Emojis.finish + ' Done, bye!', ['startinv'])
 
 
-
 class DensfJob(Job):
     def __init__(self, overwrite: bool = False, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -980,6 +979,13 @@ if __name__ == "__main__":
     # with ADFFragmentJob() as job:
     #     ...
 
+    # timer.timer_level = 40
+
     with ADFJob(test_mode=True) as job:
         job.irrep_occupations('A', '28 // 26')
         job.molecule('exammple.xyz')
+
+
+    # with ADFFragmentJob(test_mode=True) as job:
+    #     job.frag_occupations('A', '28 // 26')
+    #     job.molecule('exammple.xyz')

--- a/src/tcutility/job/ams.py
+++ b/src/tcutility/job/ams.py
@@ -1,6 +1,6 @@
 from scm import plams
 import tcutility
-from tcutility import log, connect
+from tcutility import log, connect, timer
 from tcutility.job.generic import Job
 import os
 import numpy as np
@@ -194,6 +194,7 @@ class AMSJob(Job):
         ex, ey, ez = tuple(direction)
         self.settings.input.ams.System.ElectrostaticEmbedding.ElectricField = f'{ex} {ey} {ez}'
 
+    @timer.timer
     def _setup_job(self):
         '''
         Set up the calculation. This will create the working directory and write the runscript and input file for ADF to use.

--- a/src/tcutility/job/generic.py
+++ b/src/tcutility/job/generic.py
@@ -123,12 +123,13 @@ class Job:
             This will be fixed in a later version of TCutility.
         """
         for server in self._servers:
+            # see if we can use quick_status, otherwise use the slow method
             try:
                 res = results.quick_status(self.workdir)
                 if not res.fatal:
                     return True
                 continue
-            except:
+            except Exception:
                 pass
 
             res = server.execute(f'tcutility read -s {j(server.pwd(), self.rundir, self.name)}')

--- a/src/tcutility/job/generic.py
+++ b/src/tcutility/job/generic.py
@@ -191,7 +191,7 @@ class Job:
         Run this job. We detect if we are using slurm. If we are we submit this job using sbatch. Otherwise, we will run the job locally.
         """
         if self.can_skip():
-            log.info(f"Skipping calculation {j(self.rundir, self.name)}, it is already finished or currently pending or running.")
+            log.debug(f"Skipping calculation {j(self.rundir, self.name)}, it is already finished or currently pending or running.")
             return
 
         server = self._select_server()

--- a/src/tcutility/results/__init__.py
+++ b/src/tcutility/results/__init__.py
@@ -14,7 +14,7 @@ Result = result.Result
 import os  # noqa: E402
 import pathlib as pl  # noqa: E402
 
-from .. import slurm  # noqa: E402
+from .. import slurm, timer  # noqa: E402
 from . import adf, ams, cache, dftb, orca, xtb, crest  # noqa: E402
 
 
@@ -125,6 +125,7 @@ def read(calc_dir: Union[str, pl.Path]) -> Result:
     return ret
 
 
+@timer.timer
 def quick_status(calc_dir: Union[str, pl.Path]) -> Result:
     """
     Quickly check the status of a calculation.

--- a/src/tcutility/results/ams.py
+++ b/src/tcutility/results/ams.py
@@ -215,42 +215,12 @@ def get_calculation_status(calc_dir: str) -> Result:
     ret.code = None
     ret.reasons = []
 
-    def reverse_readline(filename, buf_size=8192):
-        """A generator that returns the lines of a file in reverse order"""
-        with open(filename, 'rb') as fh:
-            segment = None
-            offset = 0
-            fh.seek(0, os.SEEK_END)
-            file_size = remaining_size = fh.tell()
-            while remaining_size > 0:
-                offset = min(file_size, offset + buf_size)
-                fh.seek(file_size - offset)
-                buffer = fh.read(min(remaining_size, buf_size))
-                # remove file's last "\n" if it exists, only for the first buffer
-                if remaining_size == file_size and buffer[-1] == ord('\n'):
-                    buffer = buffer[:-1]
-                remaining_size -= buf_size
-                lines = buffer.split('\n'.encode())
-                # append last chunk's segment to this chunk's last line
-                if segment is not None:
-                    lines[-1] += segment
-                segment = lines[0]
-                lines = lines[1:]
-                # yield lines in this chunk except the segment
-                for line in reversed(lines):
-                    # only decode on a parsed line, to avoid utf-8 decode error
-                    yield line.decode()
-            # Don't yield None if the file was empty
-            if segment is not None:
-                yield segment.decode()
-
-
     # parse the logfile to find errors and warnings
     if "log" in files:
-        # with open(files["log"]) as logfile:
-        #     lines = logfile.readlines()
+        with open(files["log"]) as logfile:
+            lines = logfile.readlines()
             # the termination status is at the end of the file, so we start reading from the end
-            for line in reverse_readline(files['log']):
+            for line in lines[::-1]:
                 # the first 25 characters include the timestamp and two spaces
                 line_ = line.strip()[25:].lower()
                 # errors and warnings have a predictable format

--- a/src/tcutility/results/ams.py
+++ b/src/tcutility/results/ams.py
@@ -215,12 +215,42 @@ def get_calculation_status(calc_dir: str) -> Result:
     ret.code = None
     ret.reasons = []
 
+    def reverse_readline(filename, buf_size=8192):
+        """A generator that returns the lines of a file in reverse order"""
+        with open(filename, 'rb') as fh:
+            segment = None
+            offset = 0
+            fh.seek(0, os.SEEK_END)
+            file_size = remaining_size = fh.tell()
+            while remaining_size > 0:
+                offset = min(file_size, offset + buf_size)
+                fh.seek(file_size - offset)
+                buffer = fh.read(min(remaining_size, buf_size))
+                # remove file's last "\n" if it exists, only for the first buffer
+                if remaining_size == file_size and buffer[-1] == ord('\n'):
+                    buffer = buffer[:-1]
+                remaining_size -= buf_size
+                lines = buffer.split('\n'.encode())
+                # append last chunk's segment to this chunk's last line
+                if segment is not None:
+                    lines[-1] += segment
+                segment = lines[0]
+                lines = lines[1:]
+                # yield lines in this chunk except the segment
+                for line in reversed(lines):
+                    # only decode on a parsed line, to avoid utf-8 decode error
+                    yield line.decode()
+            # Don't yield None if the file was empty
+            if segment is not None:
+                yield segment.decode()
+
 
     # parse the logfile to find errors and warnings
     if "log" in files:
-        with open(files["log"]) as logfile:
-            lines = logfile.readlines()
-            for line in lines[::-1]:
+        # with open(files["log"]) as logfile:
+        #     lines = logfile.readlines()
+            # the termination status is at the end of the file, so we start reading from the end
+            for line in reverse_readline(files['log']):
                 # the first 25 characters include the timestamp and two spaces
                 line_ = line.strip()[25:].lower()
                 # errors and warnings have a predictable format

--- a/src/tcutility/results/ams.py
+++ b/src/tcutility/results/ams.py
@@ -208,7 +208,6 @@ def get_calculation_status(calc_dir: str) -> Result:
             - **code (str)** – calculation status written as a single character, one of ("S", "R", "U", "W" "F")
     """
     files = get_calc_files(calc_dir)
-    reader_ams = cache.get(files["ams.rkf"])
 
     ret = Result()
     ret.fatal = True
@@ -216,17 +215,26 @@ def get_calculation_status(calc_dir: str) -> Result:
     ret.code = None
     ret.reasons = []
 
-    termination_status = str(reader_ams.read("General", "termination status")).strip()
 
     # parse the logfile to find errors and warnings
     if "log" in files:
         with open(files["log"]) as logfile:
-            for line in logfile.readlines():
+            lines = logfile.readlines()
+            for line in lines:
                 # the first 25 characters include the timestamp and two spaces
                 line_ = line.strip()[25:]
                 # errors and warnings have a predictable format
                 if line_.lower().startswith("error:") or line_.lower().startswith("warning: "):
                     ret.reasons.append(line_)
+                if "NORMAL TERMINATION" in line:
+                    ret.fatal = False
+                    ret.name = "SUCCESS"
+                    ret.code = "S"
+                    return ret
+
+
+    reader_ams = cache.get(files["ams.rkf"])
+    termination_status = str(reader_ams.read("General", "termination status")).strip()
 
     if termination_status == "NORMAL TERMINATION":
         ret.fatal = False

--- a/src/tcutility/results/ams.py
+++ b/src/tcutility/results/ams.py
@@ -220,13 +220,14 @@ def get_calculation_status(calc_dir: str) -> Result:
     if "log" in files:
         with open(files["log"]) as logfile:
             lines = logfile.readlines()
-            for line in lines:
+            for line in lines[::-1]:
                 # the first 25 characters include the timestamp and two spaces
-                line_ = line.strip()[25:]
+                line_ = line.strip()[25:].lower()
                 # errors and warnings have a predictable format
                 if line_.lower().startswith("error:") or line_.lower().startswith("warning: "):
                     ret.reasons.append(line_)
-                if "NORMAL TERMINATION" in line:
+
+                if "normal termination" in line_:
                     ret.fatal = False
                     ret.name = "SUCCESS"
                     ret.code = "S"

--- a/src/tcutility/spell_check.py
+++ b/src/tcutility/spell_check.py
@@ -117,6 +117,7 @@ def get_closest(a: str, others: List[str], compare_func=wagner_fischer, ignore_c
         a = a.lower()
         others = [other.lower() for other in others]
 
+    print(a, others)
     if a in others:
         return a
 

--- a/src/tcutility/spell_check.py
+++ b/src/tcutility/spell_check.py
@@ -1,5 +1,5 @@
 import numpy as np
-from tcutility import log
+from tcutility import log, timer
 from typing import List
 
 
@@ -158,7 +158,7 @@ def make_suggestion(a: str, others: List[str], **kwargs):
     # write a warning message
     log.warn(f'Could not find "{a}". Did you mean {closest_string}?', caller_level=3)
 
-
+@timer.timer
 def check(a: str, others: List[str], caller_level=2, **kwargs):
     closest = get_closest(a, others, **kwargs)
     if len(closest) == 0:

--- a/src/tcutility/spell_check.py
+++ b/src/tcutility/spell_check.py
@@ -118,7 +118,7 @@ def get_closest(a: str, others: List[str], compare_func=wagner_fischer, ignore_c
         others = [other.lower() for other in others]
 
     if a in others:
-        return [a]
+        return []
 
     for char in ignore_chars:
         a = a.replace(char, '')
@@ -158,6 +158,7 @@ def make_suggestion(a: str, others: List[str], **kwargs):
 
     # write a warning message
     log.warn(f'Could not find "{a}". Did you mean {closest_string}?', caller_level=3)
+
 
 @timer.timer
 def check(a: str, others: List[str], caller_level=2, **kwargs):

--- a/src/tcutility/spell_check.py
+++ b/src/tcutility/spell_check.py
@@ -115,15 +115,16 @@ def get_closest(a: str, others: List[str], compare_func=wagner_fischer, ignore_c
     '''
     if ignore_case:
         a = a.lower()
+        others = [other.lower() for other in others]
+
+    if a in others:
+        return a
 
     for char in ignore_chars:
         a = a.replace(char, '')
 
     dists = []
     for other in others:
-        if ignore_case:
-            other = other.lower()
-
         for char in ignore_chars:
             other = other.replace(char, '')
 

--- a/src/tcutility/spell_check.py
+++ b/src/tcutility/spell_check.py
@@ -117,9 +117,8 @@ def get_closest(a: str, others: List[str], compare_func=wagner_fischer, ignore_c
         a = a.lower()
         others = [other.lower() for other in others]
 
-    print(a, others)
     if a in others:
-        return a
+        return [a]
 
     for char in ignore_chars:
         a = a.replace(char, '')


### PR DESCRIPTION
I managed to improve the speed of the `Job.can_skip` method.

For a set of example calculations:
 ```
Function  Calls   Mean (s)  Time Spent (s) 
──────────────────────────────────────────────
Before    4224    0.003     14.438   
After     4224    0.001     2.406  
```

Also for the spell-checking module we have massive speed-ups.

For the same set of example calculations:
 ```
Function  Calls   Mean (s)   Time Spent (s) 
──────────────────────────────────────────────
Before    29700   0.002      62.771
After     29700   0.000      0.157
```
