### PR TITLE
Refactored the `results` module

### DIFF
--- a/src/tcutility/results2/__init__.py
+++ b/src/tcutility/results2/__init__.py
@@ -1,0 +1,9 @@
+
+
+from . import result, detect_filetype, adf, adf_rkf
+
+
+def read(path: str) -> result.NestedDict:
+	program = detect_filetype.detect_program(path)
+	if program == 'adf':
+		return adf.read_adfrkf(path)

--- a/src/tcutility/results2/adf.py
+++ b/src/tcutility/results2/adf.py
@@ -1,0 +1,57 @@
+from tcutility.results2 import result, adf_rkf
+from tcutility import cache, results, ensure_list
+import numpy as np
+
+
+def read_adfrkf(path: str, ret: result.NestedDict = None):
+    if ret is None:
+        ret = result.NestedDict()
+
+    ret.set('adf', adf_rkf._read_settings(path))
+    ret.set('properties', 'excitations', adf_rkf._read_excitations(path))
+    ret.set('properties', 'vibrations', adf_rkf._read_vibrations(path))
+
+    return ret
+
+
+if __name__ == '__main__':
+    def equal_dicts(d1: dict, d2: dict) -> bool:
+        '''
+        Test if two dictionaries are the same
+        '''
+        import dictfunc
+        for row1, row2 in zip(dictfunc.dict_to_list(d1), dictfunc.dict_to_list(d2)):
+            for x, y in zip(row1, row2):
+                if isinstance(x, np.ndarray):
+                    if (x != y).any():
+                        return False
+                else:
+                    if x != y:
+                        return False
+        return True
+
+    ref_res = results.read('/Users/yumanhordijk/PhD/Projects/Students/felix_research/test/Excitations_Approx/M06-2X_range/exc.results')
+    test_res = read_adfrkf('/Users/yumanhordijk/PhD/Projects/Students/felix_research/test/Excitations_Approx/M06-2X_range/exc.results/adf.rkf')
+
+    # print(equal_dicts(ref_res.adf, test_res.adf))
+    # print(equal_dicts(ref_res.properties.excitations, test_res.get('properties', 'excitations')))
+
+    import pprint
+
+    # pprint.pprint(ref_res.adf)
+    pprint.pprint(test_res['properties']['excitations'])
+
+
+    ref_res = results.read('/Users/yumanhordijk/PhD/Programs/TheoCheM/TCutility/test/fixtures/ethanol/geometry_optimization.results')
+    test_res = read_adfrkf('/Users/yumanhordijk/PhD/Programs/TheoCheM/TCutility/test/fixtures/ethanol/geometry_optimization.results/adf.rkf')
+    # print(test_res)
+
+    # print(equal_dicts(ref_res.adf, test_res.get('adf')))
+
+    import pprint
+
+    # pprint.pprint(ref_res.adf)
+    pprint.pprint(test_res['properties']['vibrations'])
+
+    # print(equal_dicts(ref_res.properties.vibrations, test_res.get('properties', 'vibrations')))
+

--- a/src/tcutility/results2/adf_rkf.py
+++ b/src/tcutility/results2/adf_rkf.py
@@ -1,0 +1,189 @@
+from tcutility.results2 import result, detect_filetype
+from tcutility import cache, ensure_list
+import numpy as np
+from scm import plams
+
+
+
+@cache.cache
+def get_adf_reader(path: str) -> plams.KFReader:
+    '''
+    Get the KFReader associated with the path.
+    This function is expected to be slow so we cache it.
+    '''
+    if detect_filetype.detect(path) == 'adf_rkf':
+        reader = plams.KFReader(path)
+        return reader
+
+
+def _read_settings(path: str) -> result.NestedDict:
+    """Function to read calculation settings for an ADF calculation.
+
+    Args:
+        info: result.NestedDict object containing ADF calculation settings.
+
+    Returns:
+        :result.NestedDict object containing properties from the ADF calculation:
+
+            - **task (str)** – the task that was set for the calculation.
+            - **relativistic (bool)** – whether or not relativistic effects were enabled.
+            - **relativistic_type (str)** – the name of the relativistic approximation used.
+            - **unrestricted_sfos (bool)** – whether or not SFOs are treated in an unrestricted manner.
+            - **unrestricted_mos (bool)** – whether or not MOs are treated in an unrestricted manner.
+            - **symmetry.group (str)** – the symmetry group selected for the molecule.
+            - **symmetry.labels (list[str])** – the symmetry labels associated with the symmetry group.
+            - **used_regions (bool)** – whether regions were used in the calculation.
+            - **charge (int)** - the charge of the system.
+            - **spin_polarization (int)** - the spin-polarization of the system.
+            - **multiplicity (int)** - the multiplicity of the system. This is equal to 2|S|+1 for spin-polarization S.
+    """
+    reader = get_adf_reader(path)
+    ret = result.NestedDict()
+
+    # set the calculation task at a higher level
+    ret.set('task', reader.read('General', 'runtype').title().replace(' ', ''))
+
+    relativistic_type_map = {
+        0: "None",
+        1: "scalar Pauli",
+        3: "scalar ZORA",  # scalar ZORA + MAPA
+        4: "scalar ZORA + full pot.",
+        5: "scalar ZORA + APA",
+        6: "scalar X2C + MAPA",
+        7: "scalar X2C ZORA + MAPA",
+        11: "spin-orbit Pauli",
+        13: "spin-orbit ZORA",  # spin-orbit ZORA + MAPA
+        14: "spin-orbit ZORA + full pot.",
+        15: "spin-orbit ZORA + APA",
+        16: "spin-orbit X2C + MAPA",
+        17: "spin-orbit X2C ZORA + MAPA",
+    }
+    # determine if calculation used relativistic corrections
+    # if it did, variable 'escale' will be present in 'SFOs'
+    # if it didnt, only variable 'energy' will be present
+    ret.set('relativistic_type', ("SFOs", "escale") in reader)
+    ret.set('relativistic_type', relativistic_type_map[reader.read("General", "ioprel")])
+
+    # determine if MOs are unrestricted or not
+    # general, nspin is 1 for restricted and 2 for unrestricted calculations
+    ret.set('unrestricted_mos', reader.read("General", "nspin") == 2)
+
+    # determine if SFOs are unrestricted or not
+    ret.set('unrestricted_sfos', reader.read("General", "nspinf") == 2)
+
+    # get the symmetry group
+    ret.set('symmetry', 'group', reader.read("Geometry", "grouplabel").strip())
+
+    # get the symmetry labels
+    ret.set('symmetry', 'labels', reader.read("Symmetry", "symlab").strip().split())
+
+    # determine if the calculation used regions or not
+    frag_order = reader.read("Geometry", "fragment and atomtype index")
+    frag_order = frag_order[: len(frag_order) // 2]
+    ret.set('used_regions', max(frag_order) != len(frag_order))
+
+    ret.set('charge', reader.read("Molecule", "Charge"))
+
+    ret.set('spin_polarization', 0)
+    if ret.get('unrestricted_mos'):
+        nalpha = 0
+        nbeta = 0
+        for label in ret.get('symmetry', 'labels'):
+            nalpha += sum(ensure_list(reader.read(label, "froc_A")))
+            nbeta += sum(ensure_list(reader.read(label, "froc_B")))
+        ret.set('spin_polarization', nalpha - nbeta)
+    ret.set('multiplicity', 2 * ret.get('spin_polarization') + 1)
+
+    return ret
+
+
+def _read_excitations(path: str) -> result.NestedDict:
+    reader = get_adf_reader(path)
+    ret = result.NestedDict()
+
+    # check if there are excitations
+    if not ('Symmetry', 'symlab excitations') in reader:
+        return ret
+
+    excitation_types = []
+    symlab_exc = reader.read('Symmetry', 'symlab excitations').split()
+    for section, variable in reader:
+        if not section.startswith('Excitations'):
+            continue
+
+        _, exctyp, irrep = section.split()
+        if (exctyp, irrep) in excitation_types:
+            continue
+
+        excitation_types.append((exctyp, irrep))
+
+        ret.set(irrep, exctyp, 'number_of_excitations', reader.read(section, 'nr of excenergies'))
+        ret.set(irrep, exctyp, 'energies', np.array(reader.read(section, 'excenergies')))  # in Ha
+
+        # values used to convert excitation photon energies to wavelengths
+        c = 299_792_458e9  # nm/s
+        h = 0.0367502 * 4.135_667_696e-15  # Ha s
+        ret.set(irrep, exctyp, 'wavelengths', (h * c) / ret.get(irrep, exctyp, 'energies')) # in nm
+        ret.set(irrep, exctyp, 'oscillator_strengths', np.array(reader.read(section, 'oscillator strengths')))  # in km mol
+        ret.set(irrep, exctyp, 'transition_dipole_moments', np.array(reader.read(section, 'transition dipole moments')).reshape(ret.get(irrep, exctyp, 'number_of_excitations'), 3))
+
+        ret.set(irrep, exctyp, 'contributions', [])
+        ret.set(irrep, exctyp, 'from_MO', [])
+        ret.set(irrep, exctyp, 'to_MO', [])
+        ret.set(irrep, exctyp, 'from_MO_idx', [])
+        ret.set(irrep, exctyp, 'to_MO_idx', [])
+        ret.set(irrep, exctyp, 'from_MO_spin', [])
+        ret.set(irrep, exctyp, 'to_MO_spin', [])
+        ret.set(irrep, exctyp, 'from_MO_irrep', [])
+        ret.set(irrep, exctyp, 'to_MO_irrep', [])
+
+        for exc_index in range(1, ret.get(irrep, exctyp, 'number_of_excitations') + 1):
+            contr = ensure_list(reader.read(section, f'contr {exc_index}'))
+            contr_idx = ensure_list(reader.read(section, f'contr index {exc_index}'))
+            contr_spin = ensure_list(reader.read(section, f'contr spin {exc_index}'))
+            is_unrestricted = 2 in contr_spin
+            contr_irrep = ensure_list(reader.read(section, f'contr irep index {exc_index}'))
+            ncontr = len(contr_idx) // 2 
+
+            MO_names = []
+            for idx, spin, irrep_idx in zip(contr_idx, contr_spin, contr_irrep):
+                spin = {
+                    1: 'A',
+                    2: 'B'
+                }[spin]
+                if is_unrestricted:
+                    MO_names.append(f'{idx}{symlab_exc[irrep_idx-1]}_{spin}')
+                else:
+                    MO_names.append(f'{idx}{symlab_exc[irrep_idx-1]}')
+
+            ret[irrep][exctyp]['contributions'].append(contr)
+            ret[irrep][exctyp]['from_MO'].append(MO_names[:ncontr])
+            ret[irrep][exctyp]['to_MO'].append(MO_names[ncontr:])
+            ret[irrep][exctyp]['from_MO_idx'].append(contr_idx[:ncontr])
+            ret[irrep][exctyp]['to_MO_idx'].append(contr_idx[ncontr:])
+            ret[irrep][exctyp]['from_MO_spin'].append(contr_spin[:ncontr])
+            ret[irrep][exctyp]['to_MO_spin'].append(contr_spin[ncontr:])
+            ret[irrep][exctyp]['from_MO_irrep'].append(contr_irrep[:ncontr])
+            ret[irrep][exctyp]['to_MO_irrep'].append(contr_irrep[ncontr:])
+
+    return ret
+
+
+def _read_vibrations(path: str) -> result.NestedDict:
+    reader = get_adf_reader(path)
+    ret = result.NestedDict()
+
+    # check if we have vibrations
+    if ("Vibrations", "nNormalModes") not in reader:
+        return ret
+
+    ret.set('number_of_modes', reader.read("Vibrations", "nNormalModes"))
+    ret.set('frequencies', ensure_list(reader.read("Vibrations", "Frequencies[cm-1]")))
+    if ("Vibrations", "Intensities[km/mol]") in reader:
+        ret.intensities = ensure_list(reader.read("Vibrations", "Intensities[km/mol]"))
+    ret.set('number_of_imag_modes', len([freq for freq in ret['frequencies'] if freq < 0]))
+    ret.set('character', "minimum" if ret['number_of_imag_modes'] == 0 else "transitionstate")
+    ret.set('modes', [])
+    for i in range(ret.get('number_of_modes')):
+        ret.get('modes').append(reader.read("Vibrations", f"NoWeightNormalMode({i+1})"))
+    return ret

--- a/src/tcutility/results2/detect_filetype.py
+++ b/src/tcutility/results2/detect_filetype.py
@@ -1,0 +1,192 @@
+from scm import plams
+import os
+import warnings
+import tcutility
+
+
+def _is_unicode_file(path: str) -> bool:
+	# try to open the file first
+	try:
+		with open(path) as file:
+			file.readlines()
+	except UnicodeDecodeError:
+		return False
+	return True
+
+
+def _is_float(s: str) -> bool:
+	try:
+		float(s)
+		return True
+	except ValueError:
+		return False
+
+
+def _detect_coord_path(path: str) -> str:
+	'''
+	Detect if a file is a coord file.
+	'''
+	if not _is_unicode_file(path):
+		return
+
+	with open(path) as file:
+		lines = file.readlines()
+
+	lines = [line.strip() for line in lines if line.strip()]
+
+	# first line must be $coord
+	# and final line must be $end
+	if lines[0] != '$coord':
+		return
+
+	if lines[-1] != '$end':
+		return
+
+	# check next n_atoms lines except second line which is for comments
+	body = lines[1:-2]
+
+	# check if the body matches xyz
+	for line in body:
+		if line.startswith('$'):
+			continue
+		parts = line.split()
+		if not parts[3].isalpha():
+			return
+		if not all(_is_float(part) for part in parts[:3]):
+			return
+
+	return 'coord'
+
+
+def _detect_xyz_path(path: str) -> str:
+	'''
+	Detect if a file is an xyz file.
+	'''
+	if not _is_unicode_file(path):
+		return
+
+	with open(path) as file:
+		lines = file.readlines()
+
+	# first line must be an integer
+	first_line = lines[0].strip()
+	if not first_line.isnumeric():
+		return
+	n_atoms = int(first_line)
+
+	# check next n_atoms lines except second line which is for comments
+	body = lines[2:n_atoms+2]
+	# check if the body matches xyz
+	for line in body:
+		parts = line.split()
+		# first part is element
+		if len(parts[0]) > 2:
+			return
+		if not parts[0].isalpha():
+			return
+
+		# next three parts are floats
+		if not all(_is_float(part) for part in parts[1:4]):
+			return
+
+	return 'xyz'
+
+
+def _detect_AMS_path(path: str) -> str:
+	'''
+	Detect if the file originates from an AMS calculation.
+	'''
+	# check if file is an rkf file
+	try:
+		reader = plams.KFReader(path, autodetect=False)
+		if ('General', 'program') in reader:
+			program = reader.read('General', 'program').lower()
+			return f'{program}_rkf'
+		if ('General', 'file-ident') in reader:
+			ident = reader.read('General', 'file-ident').lower()
+			if ident == 'tape21':
+				return 't21'
+
+	except (plams.core.errors.FileError, IndexError):
+		pass
+
+	except OSError:
+		return
+
+	if not _is_unicode_file(path):
+		return
+
+	# check text files
+	with open(path) as file:
+		lines = file.readlines()
+		# check for output file
+		if any('Amsterdam Modeling Suite' in line for line in lines):
+			if any('ADF 20' in line for line in lines):
+				return 'adf_out'
+
+		# and check for logfile
+		if any('ADF 20' in line and 'RunTime: ' in line for line in lines):
+			return 'adf_log'
+
+
+def _detect_CREST_path(path: str) -> str:
+	'''
+	Detect if the file originates from a CREST calculation.
+	'''
+	# check for conformer and rotamer directories
+	if not _is_unicode_file(path):
+		return
+
+	# check text files
+	with open(path) as file:
+		lines = file.readlines()
+		# check for output file
+		if any('|  Conformer-Rotamer Ensemble Sampling Tool  |' in line for line in lines):
+			return 'crest_out'
+
+
+def detect(path: str) -> str:
+	if os.path.isdir(path):
+		return 'directory'
+
+	for detect_func in [
+						_detect_xyz_path,
+						_detect_coord_path,
+						_detect_AMS_path,
+						_detect_CREST_path,
+						]:
+		typ = detect_func(path)
+		if typ is not None:
+			return typ
+
+
+def detect_program(path: str) -> str:
+	typ = detect(path)
+	if typ.startswith('adf_') or typ == 't21':
+		return 'adf'
+
+
+
+if __name__ == '__main__':
+	print(detect('/Users/yumanhordijk/PhD/Programs/TheoCheM/PyFMO/calculations/PyOrb_testing_2019/TransitionState/DielsAlder.results/Diene.t21'))
+	print(detect('/Users/yumanhordijk/PhD/Programs/TheoCheM/PyFMO/calculations/PyOrb_testing_2022/DonorAcceptor/NH3BH3.results/ams.rkf'))
+	print(detect('/Users/yumanhordijk/PhD/Programs/TheoCheM/PyFMO/calculations/PyOrb_testing_2022/DonorAcceptor/NH3BH3.results/adf.rkf'))
+	print(detect('/Users/yumanhordijk/PhD/Programs/TheoCheM/PyFMO/calculations/PyOrb_testing_2022/DonorAcceptor/NH3BH3.NH3.out'))
+	print(detect('/Users/yumanhordijk/PhD/Programs/TheoCheM/PyFMO/calculations/PyOrb_testing_2019/TransitionState/DielsAlder.out'))
+	print(detect('/Users/yumanhordijk/PhD/Programs/TheoCheM/PyFMO/calculations/PyOrb_testing_2022/DonorAcceptor/NH3BH3.NH3.logfile'))
+	print(detect('/Users/yumanhordijk/PhD/Programs/TheoCheM/PyFMO/calculations/PyOrb_testing_2019/TransitionState/DielsAlder.logfile'))
+
+
+	base = '/Users/yumanhordijk/PhD/Programs/TheoCheM/PyFMO/examples/bonding_antibonding/homolytic'
+	for root, dirs, files in os.walk(base):
+		for file in files:
+			p = os.path.join(root, file)
+			print(str(detect(p)).ljust(10), './' + os.path.relpath(p, base))
+
+	print()
+	base = '/Users/yumanhordijk/PhD/Programs/TheoCheM/TCutility/examples/job/calculations/Pentane/CREST'
+	for root, dirs, files in os.walk(base):
+		for file in files:
+			p = os.path.join(root, file)
+			# print(p)
+			print(str(detect(p)).ljust(10), './' + os.path.relpath(p, base))

--- a/src/tcutility/results2/result.py
+++ b/src/tcutility/results2/result.py
@@ -1,0 +1,79 @@
+from typing import Tuple, Any
+
+
+class NestedDict(dict):
+	def __init__(self, data=None):
+		self._priorities = {}
+		super().__init__(data or {})
+
+	def set(self, *args: Tuple[Any], priority: float = 0):
+		'''
+		Override of the standard ``dict.set`` method allowing 
+		for setting a nested key in one call.
+	
+		Args:
+			*args: an unpacked tuple of firstly keys and then the value to be set.
+			priority: the priority for setting this value. If the given priority 
+				is higher than a previously set priority we set the value, 
+				otherwise we ignore it.
+
+		Examples:
+			.. code-block:: python
+
+				>>> nd = NestedDict()
+				>>> nd.set('a', 'b', 'c', 15, priority=1)
+				>>> nd
+				{'a': {'b': {'c': 15}}}
+				>>> nd.set('a', 'b', 'c', 'overwritten?', priority=0)
+				>>> nd
+				{'a': {'b': {'c': 15}}}
+				>>> nd.get('a', 'b', 'c')
+				15
+		'''
+		keys, val = args[:-1], args[-1]
+
+		if self._priorities.get(keys, 0) > priority:
+			return
+
+		self._priorities[keys] = priority
+
+		d = self
+		for i, key in enumerate(keys):
+			d.setdefault(key, {})
+			if i == len(keys) - 1:
+				d[key] = val
+			else:
+				d = d[key]
+
+	def get(self, *keys: Tuple[Any]) -> Any:
+		'''
+		Get a nested value from this dict.
+
+		Args:
+			*keys: an unpacked tuple of keys used to access the value.
+
+		Example:
+			.. code-block:: python
+
+				>>> nd = NestedDict()
+				>>> nd.set('a', 'b', 'c', 15, priority=1)
+				>>> nd
+				{'a': {'b': {'c': 15}}}
+				>>> nd.get('a', 'b')
+				{'c': 15}
+				>>> nd.get('a', 'b', 'c')
+				15
+		'''
+		d = self
+		for key in keys:
+			if key not in d:
+				return
+			d = d[key]
+		return d
+
+
+if __name__ == '__main__':
+	nd = NestedDict()
+	nd.set('a', 'b', 'c', 15)
+	print(nd)
+	print(nd.get('a','b'))


### PR DESCRIPTION
This PR will be about the refactoring of the `results` module. This refactor should enable us to be able to read results from files and not only directories. This makes the `results` module much more flexible, especially as people often send around, for example, adf.rkf files only.